### PR TITLE
LPS-144799 site navigation item contextual menu

### DIFF
--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/layout/display/page/AssetCategoryLayoutDisplayPageDetailsProvider.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/layout/display/page/AssetCategoryLayoutDisplayPageDetailsProvider.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.asset.categories.internal.layout.display.page;
+
+import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
+import com.liferay.info.field.InfoField;
+import com.liferay.info.field.InfoFieldValue;
+import com.liferay.info.field.type.TextInfoFieldType;
+import com.liferay.info.item.InfoItemFieldValues;
+import com.liferay.info.item.InfoItemReference;
+import com.liferay.info.localized.InfoLocalizedValue;
+import com.liferay.layout.display.page.LayoutDisplayPageDetailsProvider;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+@Component(immediate = true, service = LayoutDisplayPageDetailsProvider.class)
+public class AssetCategoryLayoutDisplayPageDetailsProvider
+	implements LayoutDisplayPageDetailsProvider<AssetCategory> {
+
+	@Override
+	public String getClassName() {
+		return AssetCategory.class.getName();
+	}
+
+	@Override
+	public InfoItemFieldValues getDetails(AssetCategory assetCategory) {
+		if (assetCategory == null) {
+			return InfoItemFieldValues.builder(
+			).build();
+		}
+
+		List<InfoFieldValue<Object>> assetCategoryInfoFieldValues =
+			new ArrayList<>();
+
+		AssetVocabulary assetVocabulary =
+			_assetVocabularyLocalService.fetchAssetVocabulary(
+				assetCategory.getVocabularyId());
+
+		if (assetVocabulary != null) {
+			assetCategoryInfoFieldValues.add(
+				new InfoFieldValue<>(
+					InfoField.builder(
+					).infoFieldType(
+						TextInfoFieldType.INSTANCE
+					).name(
+						"vocabulary"
+					).labelInfoLocalizedValue(
+						InfoLocalizedValue.localize(
+							AssetCategoryLayoutDisplayPageDetailsProvider.class,
+							"vocabulary")
+					).build(),
+					InfoLocalizedValue.<String>builder(
+					).defaultLocale(
+						LocaleUtil.fromLanguageId(
+							assetVocabulary.getDefaultLanguageId())
+					).values(
+						assetVocabulary.getTitleMap()
+					).build()));
+		}
+
+		Group group = _groupLocalService.fetchGroup(assetCategory.getGroupId());
+
+		if (group != null) {
+			assetCategoryInfoFieldValues.add(
+				new InfoFieldValue<>(
+					InfoField.builder(
+					).infoFieldType(
+						TextInfoFieldType.INSTANCE
+					).name(
+						"group"
+					).labelInfoLocalizedValue(
+						InfoLocalizedValue.localize(
+							AssetCategoryLayoutDisplayPageDetailsProvider.class,
+							"site")
+					).build(),
+					InfoLocalizedValue.<String>builder(
+					).defaultLocale(
+						LocaleUtil.fromLanguageId(group.getDefaultLanguageId())
+					).values(
+						HashMapBuilder.put(
+							LanguageUtil.getAvailableLocales(),
+							locale -> group.getDescriptiveName(locale)
+						).build()
+					).build()));
+		}
+
+		return InfoItemFieldValues.builder(
+		).infoFieldValues(
+			assetCategoryInfoFieldValues
+		).infoItemReference(
+			new InfoItemReference(
+				AssetCategory.class.getName(), assetCategory.getCategoryId())
+		).build();
+	}
+
+	@Override
+	public InfoItemFieldValues getDetails(long categoryId) {
+		return getDetails(
+			_assetCategoryLocalService.fetchAssetCategory(categoryId));
+	}
+
+	@Reference
+	private AssetCategoryLocalService _assetCategoryLocalService;
+
+	@Reference
+	private AssetVocabularyLocalService _assetVocabularyLocalService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+}

--- a/modules/apps/layout/layout-display-page-api/bnd.bnd
+++ b/modules/apps/layout/layout-display-page-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Layout Display Page API
 Bundle-SymbolicName: com.liferay.layout.display.page.api
-Bundle-Version: 3.1.1
+Bundle-Version: 3.2.0
 Export-Package:\
 	com.liferay.layout.display.page,\
 	com.liferay.layout.display.page.constants

--- a/modules/apps/layout/layout-display-page-api/src/main/java/com/liferay/layout/display/page/LayoutDisplayPageDetailsProvider.java
+++ b/modules/apps/layout/layout-display-page-api/src/main/java/com/liferay/layout/display/page/LayoutDisplayPageDetailsProvider.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.layout.display.page;
+
+import com.liferay.info.item.InfoItemFieldValues;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+public interface LayoutDisplayPageDetailsProvider<T> {
+
+	public String getClassName();
+
+	public InfoItemFieldValues getDetails(long classPK);
+
+	public InfoItemFieldValues getDetails(T t);
+
+}

--- a/modules/apps/layout/layout-display-page-api/src/main/java/com/liferay/layout/display/page/LayoutDisplayPageDetailsProviderTracker.java
+++ b/modules/apps/layout/layout-display-page-api/src/main/java/com/liferay/layout/display/page/LayoutDisplayPageDetailsProviderTracker.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.layout.display.page;
+
+import java.util.List;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+public interface LayoutDisplayPageDetailsProviderTracker {
+
+	public LayoutDisplayPageDetailsProvider<?>
+		getLayoutDisplayPageDetailsProvider(String className);
+
+	public List<LayoutDisplayPageDetailsProvider<?>>
+		getLayoutDisplayPageDetailsProviders();
+
+}

--- a/modules/apps/layout/layout-display-page-api/src/main/resources/com/liferay/layout/display/page/packageinfo
+++ b/modules/apps/layout/layout-display-page-api/src/main/resources/com/liferay/layout/display/page/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 2.2.0

--- a/modules/apps/layout/layout-display-page-impl/src/main/java/com/liferay/layout/display/page/internal/LayoutDisplayPageDetailsProviderTrackerImpl.java
+++ b/modules/apps/layout/layout-display-page-impl/src/main/java/com/liferay/layout/display/page/internal/LayoutDisplayPageDetailsProviderTrackerImpl.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.layout.display.page.internal;
+
+import com.liferay.layout.display.page.LayoutDisplayPageDetailsProvider;
+import com.liferay.layout.display.page.LayoutDisplayPageDetailsProviderTracker;
+import com.liferay.osgi.service.tracker.collections.map.PropertyServiceReferenceComparator;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+@Component(service = LayoutDisplayPageDetailsProviderTracker.class)
+public class LayoutDisplayPageDetailsProviderTrackerImpl
+	implements LayoutDisplayPageDetailsProviderTracker {
+
+	@Override
+	public LayoutDisplayPageDetailsProvider<?>
+		getLayoutDisplayPageDetailsProvider(String className) {
+
+		return _layoutDisplayPageDetailsProviderServiceTrackerMap.getService(
+			className);
+	}
+
+	@Override
+	public List<LayoutDisplayPageDetailsProvider<?>>
+		getLayoutDisplayPageDetailsProviders() {
+
+		return new ArrayList(
+			_layoutDisplayPageDetailsProviderServiceTrackerMap.values());
+	}
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_layoutDisplayPageDetailsProviderServiceTrackerMap =
+			ServiceTrackerMapFactory.openSingleValueMap(
+				bundleContext,
+				(Class<LayoutDisplayPageDetailsProvider<?>>)
+					(Class<?>)LayoutDisplayPageDetailsProvider.class,
+				null,
+				(serviceReference, emitter) -> {
+					LayoutDisplayPageDetailsProvider<?>
+						layoutDisplayPageDetailsProvider =
+							bundleContext.getService(serviceReference);
+
+					try {
+						emitter.emit(
+							layoutDisplayPageDetailsProvider.getClassName());
+					}
+					finally {
+						bundleContext.ungetService(serviceReference);
+					}
+				},
+				new PropertyServiceReferenceComparator<>("service.ranking"));
+	}
+
+	private ServiceTrackerMap<String, LayoutDisplayPageDetailsProvider<?>>
+		_layoutDisplayPageDetailsProviderServiceTrackerMap;
+
+}

--- a/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/display/context/DisplayPageTypeSiteNavigationMenuTypeDisplayContext.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/display/context/DisplayPageTypeSiteNavigationMenuTypeDisplayContext.java
@@ -269,7 +269,7 @@ public class DisplayPageTypeSiteNavigationMenuTypeDisplayContext {
 			(LiferayPortletURL)liferayPortletResponse.createResourceURL();
 
 		itemTypeURL.setCopyCurrentRenderParameters(false);
-		itemTypeURL.setResourceID("/navigation_menu/get_item_type");
+		itemTypeURL.setResourceID("/navigation_menu/get_item_details");
 
 		return itemTypeURL.toString();
 	}

--- a/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/display/context/DisplayPageTypeSiteNavigationMenuTypeDisplayContext.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/display/context/DisplayPageTypeSiteNavigationMenuTypeDisplayContext.java
@@ -14,11 +14,15 @@
 
 package com.liferay.site.navigation.menu.item.display.page.internal.display.context;
 
+import com.liferay.info.field.InfoField;
+import com.liferay.info.field.InfoFieldValue;
+import com.liferay.info.item.InfoItemFieldValues;
 import com.liferay.info.item.InfoItemFormVariation;
 import com.liferay.info.item.provider.InfoItemFormVariationsProvider;
 import com.liferay.item.selector.ItemSelector;
 import com.liferay.item.selector.criteria.InfoItemItemSelectorReturnType;
 import com.liferay.item.selector.criteria.info.item.criterion.InfoItemItemSelectorCriterion;
+import com.liferay.layout.display.page.LayoutDisplayPageDetailsProvider;
 import com.liferay.layout.display.page.LayoutDisplayPageObjectProvider;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONArray;
@@ -46,7 +50,11 @@ import com.liferay.site.navigation.menu.item.display.page.internal.constants.Sit
 import com.liferay.site.navigation.menu.item.display.page.internal.type.DisplayPageTypeContext;
 import com.liferay.site.navigation.model.SiteNavigationMenuItem;
 
+import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.portlet.PortletURL;
 
@@ -189,7 +197,38 @@ public class DisplayPageTypeSiteNavigationMenuTypeDisplayContext {
 	}
 
 	public JSONArray getDataJSONArray() throws Exception {
-		return JSONFactoryUtil.createJSONArray();
+		Optional<LayoutDisplayPageDetailsProvider<?>>
+			layoutDisplayPageDetailsProviderOptional =
+				_displayPageTypeContext.
+					getLayoutDisplayPageDetailsProviderOptional();
+
+		LayoutDisplayPageDetailsProvider layoutDisplayPageDetailsProvider =
+			layoutDisplayPageDetailsProviderOptional.orElse(null);
+
+		if (layoutDisplayPageDetailsProvider == null) {
+			return JSONFactoryUtil.createJSONArray();
+		}
+
+		InfoItemFieldValues infoItemFieldValues =
+			layoutDisplayPageDetailsProvider.getDetails(getClassPK());
+
+		Collection<InfoFieldValue<Object>> infoFieldValues =
+			infoItemFieldValues.getInfoFieldValues();
+
+		Stream<InfoFieldValue<Object>> stream = infoFieldValues.stream();
+
+		return JSONUtil.toJSONArray(
+			stream.collect(Collectors.toList()),
+			infoFieldValue -> JSONUtil.put(
+				"title",
+				() -> {
+					InfoField infoField = infoFieldValue.getInfoField();
+
+					return infoField.getLabel(_themeDisplay.getLocale());
+				}
+			).put(
+				"value", infoFieldValue.getValue(_themeDisplay.getLocale())
+			));
 	}
 
 	public String getItemSubtype() {

--- a/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/display/context/DisplayPageTypeSiteNavigationMenuTypeDisplayContext.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/display/context/DisplayPageTypeSiteNavigationMenuTypeDisplayContext.java
@@ -21,6 +21,11 @@ import com.liferay.item.selector.criteria.InfoItemItemSelectorReturnType;
 import com.liferay.item.selector.criteria.info.item.criterion.InfoItemItemSelectorCriterion;
 import com.liferay.layout.display.page.LayoutDisplayPageObjectProvider;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONException;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.LiferayPortletURL;
@@ -29,6 +34,8 @@ import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
@@ -64,6 +71,20 @@ public class DisplayPageTypeSiteNavigationMenuTypeDisplayContext {
 				SiteNavigationWebKeys.SITE_NAVIGATION_MENU_ITEM);
 		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
+	}
+
+	public JSONArray getAvailableLocalesJSONArray() throws Exception {
+		return JSONUtil.toJSONArray(
+			LanguageUtil.getAvailableLocales(_themeDisplay.getSiteGroupId()),
+			locale -> {
+				String w3cLanguageId = LocaleUtil.toW3cLanguageId(locale);
+
+				return JSONUtil.put(
+					"label", w3cLanguageId
+				).put(
+					"symbol", StringUtil.toLowerCase(w3cLanguageId)
+				);
+			});
 	}
 
 	public Map<String, Object> getChooseInfoItemButtonContext(
@@ -167,6 +188,10 @@ public class DisplayPageTypeSiteNavigationMenuTypeDisplayContext {
 		return _classTypeId;
 	}
 
+	public JSONArray getDataJSONArray() throws Exception {
+		return JSONFactoryUtil.createJSONArray();
+	}
+
 	public String getItemSubtype() {
 		InfoItemFormVariationsProvider<?> infoItemFormVariationsProvider =
 			_displayPageTypeContext.getInfoItemFormVariationsProvider();
@@ -208,6 +233,22 @@ public class DisplayPageTypeSiteNavigationMenuTypeDisplayContext {
 		itemTypeURL.setResourceID("/navigation_menu/get_item_type");
 
 		return itemTypeURL.toString();
+	}
+
+	public JSONObject getLocalizedNamesJSONObject() throws JSONException {
+		if (_localizedNamesJSONObject != null) {
+			return _localizedNamesJSONObject;
+		}
+
+		UnicodeProperties typeSettingsUnicodeProperties =
+			UnicodePropertiesBuilder.fastLoad(
+				_siteNavigationMenuItem.getTypeSettings()
+			).build();
+
+		_localizedNamesJSONObject = JSONFactoryUtil.createJSONObject(
+			typeSettingsUnicodeProperties.getProperty("localizedNames", "{}"));
+
+		return _localizedNamesJSONObject;
 	}
 
 	public String getOriginalTitle() {
@@ -269,6 +310,22 @@ public class DisplayPageTypeSiteNavigationMenuTypeDisplayContext {
 			multipleSelectionEnabled();
 	}
 
+	public boolean isUseCustomName() {
+		if (_useCustomName != null) {
+			return _useCustomName;
+		}
+
+		UnicodeProperties typeSettingsUnicodeProperties =
+			UnicodePropertiesBuilder.fastLoad(
+				_siteNavigationMenuItem.getTypeSettings()
+			).build();
+
+		_useCustomName = GetterUtil.getBoolean(
+			typeSettingsUnicodeProperties.get("useCustomName"));
+
+		return _useCustomName;
+	}
+
 	private LayoutDisplayPageObjectProvider<?>
 		_getLayoutDisplayPageObjectProvider() {
 
@@ -289,10 +346,12 @@ public class DisplayPageTypeSiteNavigationMenuTypeDisplayContext {
 	private final DisplayPageTypeContext _displayPageTypeContext;
 	private final ItemSelector _itemSelector;
 	private LayoutDisplayPageObjectProvider<?> _layoutDisplayPageObjectProvider;
+	private JSONObject _localizedNamesJSONObject;
 	private String _originalTitle;
 	private final SiteNavigationMenuItem _siteNavigationMenuItem;
 	private final ThemeDisplay _themeDisplay;
 	private String _title;
 	private String _type;
+	private Boolean _useCustomName;
 
 }

--- a/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/portlet/action/AddDisplayPageTypeSiteNavigationMenuItemMVCActionCommand.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/portlet/action/AddDisplayPageTypeSiteNavigationMenuItemMVCActionCommand.java
@@ -28,7 +28,7 @@ import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.site.navigation.admin.constants.SiteNavigationAdminPortletKeys;
@@ -75,22 +75,6 @@ public class AddDisplayPageTypeSiteNavigationMenuItemMVCActionCommand
 			ThemeDisplay themeDisplay =
 				(ThemeDisplay)actionRequest.getAttribute(WebKeys.THEME_DISPLAY);
 
-			UnicodeProperties typeSettingsUnicodeProperties =
-				new UnicodeProperties(true);
-
-			typeSettingsUnicodeProperties.setProperty(
-				"classNameId", String.valueOf(classNameId));
-			typeSettingsUnicodeProperties.setProperty(
-				"classTypeId",
-				String.valueOf(
-					ParamUtil.getLong(actionRequest, "classTypeId")));
-			typeSettingsUnicodeProperties.setProperty(
-				"classPK", String.valueOf(classPK));
-			typeSettingsUnicodeProperties.setProperty(
-				"title", ParamUtil.getString(actionRequest, "title"));
-			typeSettingsUnicodeProperties.setProperty(
-				"type", ParamUtil.getString(actionRequest, "type"));
-
 			ServiceContext serviceContext = ServiceContextFactory.getInstance(
 				actionRequest);
 
@@ -98,7 +82,24 @@ public class AddDisplayPageTypeSiteNavigationMenuItemMVCActionCommand
 				_siteNavigationMenuItemService.addSiteNavigationMenuItem(
 					themeDisplay.getScopeGroupId(), siteNavigationMenuId, 0,
 					siteNavigationMenuItemType,
-					typeSettingsUnicodeProperties.toString(), serviceContext);
+					UnicodePropertiesBuilder.create(
+						true
+					).put(
+						"className", siteNavigationMenuItemType
+					).put(
+						"classNameId", String.valueOf(classNameId)
+					).put(
+						"classPK", String.valueOf(classPK)
+					).put(
+						"classTypeId",
+						String.valueOf(
+							ParamUtil.getLong(actionRequest, "classTypeId"))
+					).put(
+						"title", ParamUtil.getString(actionRequest, "title")
+					).put(
+						"type", ParamUtil.getString(actionRequest, "type")
+					).buildString(),
+					serviceContext);
 			}
 			catch (SiteNavigationMenuItemNameException
 						siteNavigationMenuItemNameException) {

--- a/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/portlet/action/GetItemDetailsMVCResourceCommand.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/portlet/action/GetItemDetailsMVCResourceCommand.java
@@ -63,11 +63,11 @@ import org.osgi.service.component.annotations.Reference;
 	immediate = true,
 	property = {
 		"javax.portlet.name=" + SiteNavigationAdminPortletKeys.SITE_NAVIGATION_ADMIN,
-		"mvc.command.name=/navigation_menu/get_item_type"
+		"mvc.command.name=/navigation_menu/get_item_details"
 	},
 	service = MVCResourceCommand.class
 )
-public class GetItemTypeMVCResourceCommand extends BaseMVCResourceCommand {
+public class GetItemDetailsMVCResourceCommand extends BaseMVCResourceCommand {
 
 	@Override
 	protected void doServeResource(
@@ -215,7 +215,7 @@ public class GetItemTypeMVCResourceCommand extends BaseMVCResourceCommand {
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
-		GetItemTypeMVCResourceCommand.class);
+		GetItemDetailsMVCResourceCommand.class);
 
 	@Reference
 	private InfoItemServiceTracker _infoItemServiceTracker;

--- a/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/portlet/action/GetItemTypeMVCResourceCommand.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/portlet/action/GetItemTypeMVCResourceCommand.java
@@ -14,16 +14,22 @@
 
 package com.liferay.site.navigation.menu.item.display.page.internal.portlet.action;
 
+import com.liferay.info.field.InfoField;
+import com.liferay.info.field.InfoFieldValue;
 import com.liferay.info.item.InfoItemClassDetails;
+import com.liferay.info.item.InfoItemFieldValues;
 import com.liferay.info.item.InfoItemFormVariation;
 import com.liferay.info.item.InfoItemReference;
 import com.liferay.info.item.InfoItemServiceTracker;
 import com.liferay.info.item.provider.InfoItemDetailsProvider;
 import com.liferay.info.item.provider.InfoItemFormVariationsProvider;
+import com.liferay.layout.display.page.LayoutDisplayPageDetailsProvider;
+import com.liferay.layout.display.page.LayoutDisplayPageDetailsProviderTracker;
 import com.liferay.layout.display.page.LayoutDisplayPageObjectProvider;
 import com.liferay.layout.display.page.LayoutDisplayPageProvider;
 import com.liferay.layout.display.page.LayoutDisplayPageProviderTracker;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -39,6 +45,10 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.site.navigation.admin.constants.SiteNavigationAdminPortletKeys;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.portlet.ResourceRequest;
 import javax.portlet.ResourceResponse;
@@ -87,6 +97,10 @@ public class GetItemTypeMVCResourceCommand extends BaseMVCResourceCommand {
 				jsonObject.put("itemSubtype", itemSubtype);
 			}
 
+			jsonObject.put(
+				"data",
+				_getDetailsJSONArray(classNameId, classPK, themeDisplay));
+
 			JSONPortletResponseUtil.writeJSON(
 				resourceRequest, resourceResponse, jsonObject);
 		}
@@ -101,6 +115,41 @@ public class GetItemTypeMVCResourceCommand extends BaseMVCResourceCommand {
 						themeDisplay.getRequest(),
 						"an-unexpected-error-occurred")));
 		}
+	}
+
+	private JSONArray _getDetailsJSONArray(
+			long classNameId, long classPK, ThemeDisplay themeDisplay)
+		throws Exception {
+
+		LayoutDisplayPageDetailsProvider layoutDisplayPageDetailsProvider =
+			_layoutDisplayPageDetailsProviderTracker.
+				getLayoutDisplayPageDetailsProvider(
+					_portal.getClassName(classNameId));
+
+		if (layoutDisplayPageDetailsProvider == null) {
+			return JSONFactoryUtil.createJSONArray();
+		}
+
+		InfoItemFieldValues infoItemFieldValues =
+			layoutDisplayPageDetailsProvider.getDetails(classPK);
+
+		Collection<InfoFieldValue<Object>> infoFieldValues =
+			infoItemFieldValues.getInfoFieldValues();
+
+		Stream<InfoFieldValue<Object>> stream = infoFieldValues.stream();
+
+		return JSONUtil.toJSONArray(
+			stream.collect(Collectors.toList()),
+			infoFieldValue -> JSONUtil.put(
+				"title",
+				() -> {
+					InfoField infoField = infoFieldValue.getInfoField();
+
+					return infoField.getLabel(themeDisplay.getLocale());
+				}
+			).put(
+				"value", infoFieldValue.getValue(themeDisplay.getLocale())
+			));
 	}
 
 	private String _getItemSubtype(
@@ -170,6 +219,10 @@ public class GetItemTypeMVCResourceCommand extends BaseMVCResourceCommand {
 
 	@Reference
 	private InfoItemServiceTracker _infoItemServiceTracker;
+
+	@Reference
+	private LayoutDisplayPageDetailsProviderTracker
+		_layoutDisplayPageDetailsProviderTracker;
 
 	@Reference
 	private LayoutDisplayPageProviderTracker _layoutDisplayPageProviderTracker;

--- a/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/type/DisplayPageTypeContext.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/type/DisplayPageTypeContext.java
@@ -19,6 +19,8 @@ import com.liferay.info.item.InfoItemReference;
 import com.liferay.info.item.InfoItemServiceTracker;
 import com.liferay.info.item.provider.InfoItemDetailsProvider;
 import com.liferay.info.item.provider.InfoItemFormVariationsProvider;
+import com.liferay.layout.display.page.LayoutDisplayPageDetailsProvider;
+import com.liferay.layout.display.page.LayoutDisplayPageDetailsProviderTracker;
 import com.liferay.layout.display.page.LayoutDisplayPageMultiSelectionProvider;
 import com.liferay.layout.display.page.LayoutDisplayPageMultiSelectionProviderTracker;
 import com.liferay.layout.display.page.LayoutDisplayPageObjectProvider;
@@ -35,12 +37,16 @@ public class DisplayPageTypeContext {
 
 	public DisplayPageTypeContext(
 		String className, InfoItemServiceTracker infoItemServiceTracker,
+		LayoutDisplayPageDetailsProviderTracker
+			layoutDisplayPageDetailsProviderTracker,
 		LayoutDisplayPageMultiSelectionProviderTracker
 			layoutDisplayPageMultiSelectionProviderTracker,
 		LayoutDisplayPageProviderTracker layoutDisplayPageProviderTracker) {
 
 		_className = className;
 		_infoItemServiceTracker = infoItemServiceTracker;
+		_layoutDisplayPageDetailsProviderTracker =
+			layoutDisplayPageDetailsProviderTracker;
 		_layoutDisplayPageMultiSelectionProviderTracker =
 			layoutDisplayPageMultiSelectionProviderTracker;
 		_layoutDisplayPageProviderTracker = layoutDisplayPageProviderTracker;
@@ -79,6 +85,14 @@ public class DisplayPageTypeContext {
 		return infoItemClassDetails.getLabel(locale);
 	}
 
+	public Optional<LayoutDisplayPageDetailsProvider<?>>
+		getLayoutDisplayPageDetailsProviderOptional() {
+
+		return Optional.ofNullable(
+			_layoutDisplayPageDetailsProviderTracker.
+				getLayoutDisplayPageDetailsProvider(_className));
+	}
+
 	public Optional<LayoutDisplayPageMultiSelectionProvider<?>>
 		getLayoutDisplayPageMultiSelectionProviderOptional() {
 
@@ -108,6 +122,8 @@ public class DisplayPageTypeContext {
 
 	private final String _className;
 	private final InfoItemServiceTracker _infoItemServiceTracker;
+	private final LayoutDisplayPageDetailsProviderTracker
+		_layoutDisplayPageDetailsProviderTracker;
 	private final LayoutDisplayPageMultiSelectionProviderTracker
 		_layoutDisplayPageMultiSelectionProviderTracker;
 	private final LayoutDisplayPageProviderTracker

--- a/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/type/provider/DisplayPageSiteNavigationMenuItemTypeProviderTrackerImpl.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/type/provider/DisplayPageSiteNavigationMenuItemTypeProviderTrackerImpl.java
@@ -20,6 +20,7 @@ import com.liferay.info.item.InfoItemServiceTracker;
 import com.liferay.info.item.capability.InfoItemCapability;
 import com.liferay.info.item.provider.InfoItemCapabilitiesProvider;
 import com.liferay.item.selector.ItemSelector;
+import com.liferay.layout.display.page.LayoutDisplayPageDetailsProviderTracker;
 import com.liferay.layout.display.page.LayoutDisplayPageMultiSelectionProviderTracker;
 import com.liferay.layout.display.page.LayoutDisplayPageProviderTracker;
 import com.liferay.layout.page.template.info.item.capability.DisplayPageInfoItemCapability;
@@ -98,6 +99,10 @@ public class DisplayPageSiteNavigationMenuItemTypeProviderTrackerImpl {
 	private JSPRenderer _jspRenderer;
 
 	@Reference
+	private LayoutDisplayPageDetailsProviderTracker
+		_layoutDisplayPageDetailsProviderTracker;
+
+	@Reference
 	private LayoutDisplayPageMultiSelectionProviderTracker
 		_layoutDisplayPageMultiSelectionProviderTracker;
 
@@ -173,6 +178,7 @@ public class DisplayPageSiteNavigationMenuItemTypeProviderTrackerImpl {
 							_assetDisplayPageFriendlyURLProvider,
 							new DisplayPageTypeContext(
 								className, _infoItemServiceTracker,
+								_layoutDisplayPageDetailsProviderTracker,
 								_layoutDisplayPageMultiSelectionProviderTracker,
 								_layoutDisplayPageProviderTracker),
 							_itemSelector, _jspRenderer, _portal,

--- a/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/resources/META-INF/resources/edit_display_page_type.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/resources/META-INF/resources/edit_display_page_type.jsp
@@ -37,6 +37,8 @@ DisplayPageTypeSiteNavigationMenuTypeDisplayContext displayPageTypeSiteNavigatio
 						).put(
 							"classTypeId", displayPageTypeSiteNavigationMenuTypeDisplayContext.getClassTypeId()
 						).put(
+							"data", displayPageTypeSiteNavigationMenuTypeDisplayContext.getDataJSONArray()
+						).put(
 							"title", displayPageTypeSiteNavigationMenuTypeDisplayContext.getTitle()
 						).put(
 							"type", displayPageTypeSiteNavigationMenuTypeDisplayContext.getType()
@@ -46,7 +48,13 @@ DisplayPageTypeSiteNavigationMenuTypeDisplayContext displayPageTypeSiteNavigatio
 					).put(
 						"itemType", displayPageTypeSiteNavigationMenuTypeDisplayContext.getItemType()
 					).put(
+						"locales", displayPageTypeSiteNavigationMenuTypeDisplayContext.getAvailableLocalesJSONArray()
+					).put(
+						"localizedNames", displayPageTypeSiteNavigationMenuTypeDisplayContext.getLocalizedNamesJSONObject()
+					).put(
 						"namespace", liferayPortletResponse.getNamespace()
+					).put(
+						"useCustomName", displayPageTypeSiteNavigationMenuTypeDisplayContext.isUseCustomName()
 					).build()
 				%>'
 			/>

--- a/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/resources/META-INF/resources/js/DisplayPageItemContextualSidebar.js
+++ b/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/resources/META-INF/resources/js/DisplayPageItemContextualSidebar.js
@@ -13,7 +13,9 @@
  */
 
 import {ClayButtonWithIcon} from '@clayui/button';
-import ClayForm, {ClayInput} from '@clayui/form';
+import ClayForm, {ClayCheckbox, ClayInput} from '@clayui/form';
+import ClayIcon from '@clayui/icon';
+import ClayLocalizedInput from '@clayui/localized-input';
 import {openSelectionModal} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
@@ -23,8 +25,15 @@ function DisplayPageItemContextualSidebar({
 	item,
 	itemSubtype,
 	itemType,
+	locales,
+	localizedNames,
 	namespace,
 }) {
+	const [translations, setTranslations] = useState(localizedNames);
+	const [useCustomName, setUseCustomName] = useState(
+		Object.keys(localizedNames).length
+	);
+	const [selectedLocale, setSelectedLocale] = useState(locales[0]);
 	const [selectedItem, setSelectedItem] = useState(item);
 
 	const {eventName, itemSelectorURL, modalTitle} = chooseItemProps;
@@ -67,17 +76,30 @@ function DisplayPageItemContextualSidebar({
 
 	return (
 		<>
-			<ClayForm.Group>
-				<label htmlFor={`${namespace}_nameInput`}>
-					{Liferay.Language.get('name')}
-				</label>
+			<ClayForm.Group className="align-items-center d-flex mb-2">
+				<ClayCheckbox
+					checked={useCustomName}
+					label={Liferay.Language.get('use-custom-name')}
+					onChange={() => setUseCustomName(!useCustomName)}
+				/>
 
-				<ClayInput
-					disabled
-					id={`${namespace}_nameInput`}
-					readOnly
-					type="text"
-					value={selectedItem.title}
+				<span
+					className="mb-3 ml-1"
+					data-tooltip-align="top"
+					title={Liferay.Language.get('use-custom-name-help')}
+				>
+					<ClayIcon symbol="question-circle-full" />
+				</span>
+			</ClayForm.Group>
+			<ClayForm.Group>
+				<ClayLocalizedInput
+					disabled={!useCustomName}
+					label={Liferay.Language.get('name')}
+					locales={locales}
+					onSelectedLocaleChange={setSelectedLocale}
+					onTranslationsChange={setTranslations}
+					selectedLocale={selectedLocale}
+					translations={translations}
 				/>
 			</ClayForm.Group>
 
@@ -147,10 +169,12 @@ DisplayPageItemContextualSidebar.propTypes = {
 	}).isRequired,
 	itemSubtype: PropTypes.string,
 	itemType: PropTypes.string.isRequired,
+	locales: PropTypes.object.isRequired,
+	localizedNames: PropTypes.object.isRequired,
 	namespace: PropTypes.string.isRequired,
 };
 
-function FormValues({namespace, selectedItem}) {
+function FormValues({localizedNames, namespace, selectedItem}) {
 	return (
 		<>
 			<input
@@ -183,11 +207,18 @@ function FormValues({namespace, selectedItem}) {
 				readOnly
 				value={selectedItem.type || ''}
 			/>
+			<input
+				hidden
+				name={getFieldName(namespace, 'localizedNames')}
+				readOnly
+				value={JSON.stringify(localizedNames)}
+			/>
 		</>
 	);
 }
 
 FormValues.propTypes = {
+	localizedNames: PropTypes.object.isRequired,
 	namespace: PropTypes.string.isRequired,
 	selectedItem: PropTypes.shape({
 		classNameId: PropTypes.string,

--- a/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/resources/META-INF/resources/js/DisplayPageItemContextualSidebar.js
+++ b/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/resources/META-INF/resources/js/DisplayPageItemContextualSidebar.js
@@ -153,6 +153,17 @@ function DisplayPageItemContextualSidebar({
 				</ClayForm.Group>
 			)}
 
+			{!!selectedItem.data.length &&
+				selectedItem.data.map(({title, value}) => (
+					<ClayForm.Group key={title}>
+						<div className="list-group">
+							<p className="list-group-title">{title}</p>
+
+							<p className="list-group-text">{value}</p>
+						</div>
+					</ClayForm.Group>
+				))}
+
 			<FormValues namespace={namespace} selectedItem={selectedItem} />
 		</>
 	);
@@ -164,6 +175,7 @@ DisplayPageItemContextualSidebar.propTypes = {
 		classNameId: PropTypes.string,
 		classPK: PropTypes.string,
 		classTypeId: PropTypes.string,
+		data: PropTypes.array,
 		title: PropTypes.string,
 		type: PropTypes.string,
 	}).isRequired,
@@ -224,6 +236,7 @@ FormValues.propTypes = {
 		classNameId: PropTypes.string,
 		classPK: PropTypes.string,
 		classTypeId: PropTypes.string,
+		data: PropTypes.array,
 		title: PropTypes.string,
 		type: PropTypes.string,
 	}).isRequired,


### PR DESCRIPTION
- Pendiente:
-> Formato y nombre de name (cuando lo tengamos claro, implemento que funcione, es decir que use el título custom si está marcado), de momento lo he dejado como localizedNames.
-> Que data traiga lo que toca (estoy en ello... )

- Al cambiar de item se rompe, creo que es porque espera que el JSON que te llega del item selector tenga el data. Podría implementarse que lo tenga, pero me parece que esto es algo muy específico de menú y que deberíamos restringirlo a aquí, así que propongo que el data lo consigas del mismo modo que el tipo y el subtipo que pones ahí, usando el mismo resourceCommand que añada una propiedad data.

- Al salvar lo que llega al servidor:
-> localizedName llega vacío.
-> Faltan los campos title y classNameId (al menos no llega)
-> Falta el campo useCustomName