### PR TITLE
LPS 181477

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/internal/display/context/SelectAssetDisplayPageDisplayContext.java
+++ b/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/internal/display/context/SelectAssetDisplayPageDisplayContext.java
@@ -135,7 +135,6 @@ public class SelectAssetDisplayPageDisplayContext {
 			layoutItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
 				new UUIDItemSelectorReturnType());
 			layoutItemSelectorCriterion.setShowBreadcrumb(false);
-			layoutItemSelectorCriterion.setShowHiddenPages(true);
 
 			itemSelectorCriteria.add(layoutItemSelectorCriterion);
 		}

--- a/modules/apps/commerce/commerce-product-asset-categories-web/src/main/java/com/liferay/commerce/product/asset/categories/web/internal/display/context/CategoryCPDisplayLayoutDisplayContext.java
+++ b/modules/apps/commerce/commerce-product-asset-categories-web/src/main/java/com/liferay/commerce/product/asset/categories/web/internal/display/context/CategoryCPDisplayLayoutDisplayContext.java
@@ -211,8 +211,6 @@ public class CategoryCPDisplayLayoutDisplayContext
 		LayoutItemSelectorCriterion layoutItemSelectorCriterion =
 			new LayoutItemSelectorCriterion();
 
-		layoutItemSelectorCriterion.setShowPrivatePages(true);
-		layoutItemSelectorCriterion.setShowPublicPages(true);
 		layoutItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
 			Collections.<ItemSelectorReturnType>singletonList(
 				new UUIDItemSelectorReturnType()));

--- a/modules/apps/commerce/commerce-product-asset-categories-web/src/main/java/com/liferay/commerce/product/asset/categories/web/internal/display/context/CategoryCPDisplayLayoutDisplayContext.java
+++ b/modules/apps/commerce/commerce-product-asset-categories-web/src/main/java/com/liferay/commerce/product/asset/categories/web/internal/display/context/CategoryCPDisplayLayoutDisplayContext.java
@@ -211,7 +211,6 @@ public class CategoryCPDisplayLayoutDisplayContext
 		LayoutItemSelectorCriterion layoutItemSelectorCriterion =
 			new LayoutItemSelectorCriterion();
 
-		layoutItemSelectorCriterion.setShowHiddenPages(true);
 		layoutItemSelectorCriterion.setShowPrivatePages(true);
 		layoutItemSelectorCriterion.setShowPublicPages(true);
 		layoutItemSelectorCriterion.setDesiredItemSelectorReturnTypes(

--- a/modules/apps/commerce/commerce-product-definitions-web/src/main/java/com/liferay/commerce/product/definitions/web/internal/display/context/CPDefinitionDisplayLayoutDisplayContext.java
+++ b/modules/apps/commerce/commerce-product-definitions-web/src/main/java/com/liferay/commerce/product/definitions/web/internal/display/context/CPDefinitionDisplayLayoutDisplayContext.java
@@ -198,8 +198,6 @@ public class CPDefinitionDisplayLayoutDisplayContext
 		LayoutItemSelectorCriterion layoutItemSelectorCriterion =
 			new LayoutItemSelectorCriterion();
 
-		layoutItemSelectorCriterion.setShowPrivatePages(true);
-		layoutItemSelectorCriterion.setShowPublicPages(true);
 		layoutItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
 			Collections.<ItemSelectorReturnType>singletonList(
 				new UUIDItemSelectorReturnType()));

--- a/modules/apps/commerce/commerce-product-definitions-web/src/main/java/com/liferay/commerce/product/definitions/web/internal/display/context/CPDefinitionDisplayLayoutDisplayContext.java
+++ b/modules/apps/commerce/commerce-product-definitions-web/src/main/java/com/liferay/commerce/product/definitions/web/internal/display/context/CPDefinitionDisplayLayoutDisplayContext.java
@@ -198,7 +198,6 @@ public class CPDefinitionDisplayLayoutDisplayContext
 		LayoutItemSelectorCriterion layoutItemSelectorCriterion =
 			new LayoutItemSelectorCriterion();
 
-		layoutItemSelectorCriterion.setShowHiddenPages(true);
 		layoutItemSelectorCriterion.setShowPrivatePages(true);
 		layoutItemSelectorCriterion.setShowPublicPages(true);
 		layoutItemSelectorCriterion.setDesiredItemSelectorReturnTypes(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/java/com/liferay/dynamic/data/mapping/taglib/servlet/taglib/HTMLTag.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/java/com/liferay/dynamic/data/mapping/taglib/servlet/taglib/HTMLTag.java
@@ -200,7 +200,6 @@ public class HTMLTag extends BaseHTMLTag {
 
 		layoutItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
 			new UUIDItemSelectorReturnType());
-		layoutItemSelectorCriterion.setShowHiddenPages(true);
 		layoutItemSelectorCriterion.setShowPrivatePages(true);
 		layoutItemSelectorCriterion.setShowPublicPages(true);
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/java/com/liferay/dynamic/data/mapping/taglib/servlet/taglib/HTMLTag.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/java/com/liferay/dynamic/data/mapping/taglib/servlet/taglib/HTMLTag.java
@@ -200,8 +200,6 @@ public class HTMLTag extends BaseHTMLTag {
 
 		layoutItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
 			new UUIDItemSelectorReturnType());
-		layoutItemSelectorCriterion.setShowPrivatePages(true);
-		layoutItemSelectorCriterion.setShowPublicPages(true);
 
 		return String.valueOf(
 			itemSelector.getItemSelectorURL(

--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/java/com/liferay/frontend/editor/alloyeditor/web/internal/editor/configuration/BaseAlloyEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/java/com/liferay/frontend/editor/alloyeditor/web/internal/editor/configuration/BaseAlloyEditorConfigContributor.java
@@ -102,7 +102,6 @@ public abstract class BaseAlloyEditorConfigContributor
 
 		layoutItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
 			new URLItemSelectorReturnType());
-		layoutItemSelectorCriterion.setShowHiddenPages(true);
 
 		jsonObject.put(
 			"documentBrowseLinkUrl",

--- a/modules/apps/item-selector/item-selector-editor-configuration/src/main/java/com/liferay/item/selector/editor/configuration/internal/DocumentsAndMediaURLEditorConfigContributor.java
+++ b/modules/apps/item-selector/item-selector-editor-configuration/src/main/java/com/liferay/item/selector/editor/configuration/internal/DocumentsAndMediaURLEditorConfigContributor.java
@@ -52,7 +52,6 @@ public class DocumentsAndMediaURLEditorConfigContributor
 
 		layoutItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
 			new URLItemSelectorReturnType());
-		layoutItemSelectorCriterion.setShowHiddenPages(true);
 
 		jsonObject.put(
 			"filebrowserBrowseUrl",

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
@@ -1346,7 +1346,6 @@ public class JournalEditArticleDisplayContext {
 			layoutItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
 				new UUIDItemSelectorReturnType());
 			layoutItemSelectorCriterion.setShowBreadcrumb(false);
-			layoutItemSelectorCriterion.setShowHiddenPages(true);
 
 			itemSelectorCriteria.add(layoutItemSelectorCriterion);
 		}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -1446,7 +1446,6 @@ public class ContentPageEditorDisplayContext {
 		layoutItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
 			new UUIDItemSelectorReturnType());
 		layoutItemSelectorCriterion.setMultiSelection(false);
-		layoutItemSelectorCriterion.setShowHiddenPages(true);
 		layoutItemSelectorCriterion.setShowPrivatePages(true);
 
 		return String.valueOf(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -1446,7 +1446,6 @@ public class ContentPageEditorDisplayContext {
 		layoutItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
 			new UUIDItemSelectorReturnType());
 		layoutItemSelectorCriterion.setMultiSelection(false);
-		layoutItemSelectorCriterion.setShowPrivatePages(true);
 
 		return String.valueOf(
 			_itemSelector.getItemSelectorURL(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkEditorConfigContributor.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkEditorConfigContributor.java
@@ -109,7 +109,6 @@ public class FragmentEntryLinkEditorConfigContributor
 
 		layoutItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
 			new URLItemSelectorReturnType());
-		layoutItemSelectorCriterion.setShowHiddenPages(true);
 
 		return layoutItemSelectorCriterion;
 	}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkRichTextEditorConfigContributor.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkRichTextEditorConfigContributor.java
@@ -119,7 +119,6 @@ public class FragmentEntryLinkRichTextEditorConfigContributor
 
 		layoutItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
 			new URLItemSelectorReturnType());
-		layoutItemSelectorCriterion.setShowHiddenPages(true);
 
 		return layoutItemSelectorCriterion;
 	}

--- a/modules/apps/layout/layout-dynamic-data-mapping-form-field-type/src/main/java/com/liferay/layout/dynamic/data/mapping/form/field/type/internal/LayoutDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/layout/layout-dynamic-data-mapping-form-field-type/src/main/java/com/liferay/layout/dynamic/data/mapping/form/field/type/internal/LayoutDDMFormFieldTemplateContextContributor.java
@@ -105,7 +105,6 @@ public class LayoutDDMFormFieldTemplateContextContributor
 
 		layoutItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
 			new UUIDItemSelectorReturnType());
-		layoutItemSelectorCriterion.setShowHiddenPages(true);
 		layoutItemSelectorCriterion.setShowPrivatePages(true);
 		layoutItemSelectorCriterion.setShowPublicPages(true);
 

--- a/modules/apps/layout/layout-dynamic-data-mapping-form-field-type/src/main/java/com/liferay/layout/dynamic/data/mapping/form/field/type/internal/LayoutDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/layout/layout-dynamic-data-mapping-form-field-type/src/main/java/com/liferay/layout/dynamic/data/mapping/form/field/type/internal/LayoutDDMFormFieldTemplateContextContributor.java
@@ -105,8 +105,6 @@ public class LayoutDDMFormFieldTemplateContextContributor
 
 		layoutItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
 			new UUIDItemSelectorReturnType());
-		layoutItemSelectorCriterion.setShowPrivatePages(true);
-		layoutItemSelectorCriterion.setShowPublicPages(true);
 
 		return String.valueOf(
 			_itemSelector.getItemSelectorURL(

--- a/modules/apps/layout/layout-item-selector-api/bnd.bnd
+++ b/modules/apps/layout/layout-item-selector-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Layout Item Selector API
 Bundle-SymbolicName: com.liferay.layout.item.selector.api
-Bundle-Version: 5.2.5
+Bundle-Version: 6.0.0
 Export-Package:\
 	com.liferay.layout.item.selector,\
 	com.liferay.layout.item.selector.criterion,\

--- a/modules/apps/layout/layout-item-selector-api/src/main/java/com/liferay/layout/item/selector/criterion/LayoutItemSelectorCriterion.java
+++ b/modules/apps/layout/layout-item-selector-api/src/main/java/com/liferay/layout/item/selector/criterion/LayoutItemSelectorCriterion.java
@@ -46,10 +46,6 @@ public class LayoutItemSelectorCriterion extends BaseItemSelectorCriterion {
 		return _showDraftPages;
 	}
 
-	public boolean isShowHiddenPages() {
-		return _showHiddenPages;
-	}
-
 	public boolean isShowPrivatePages() {
 		return _showPrivatePages;
 	}
@@ -86,10 +82,6 @@ public class LayoutItemSelectorCriterion extends BaseItemSelectorCriterion {
 		_showDraftPages = showDraftPages;
 	}
 
-	public void setShowHiddenPages(boolean showHiddenPages) {
-		_showHiddenPages = showHiddenPages;
-	}
-
 	public void setShowPrivatePages(boolean showPrivatePages) {
 		_showPrivatePages = showPrivatePages;
 	}
@@ -105,7 +97,6 @@ public class LayoutItemSelectorCriterion extends BaseItemSelectorCriterion {
 	private boolean _showActionsMenu;
 	private boolean _showBreadcrumb;
 	private boolean _showDraftPages;
-	private boolean _showHiddenPages;
 	private boolean _showPrivatePages;
 	private boolean _showPublicPages;
 

--- a/modules/apps/layout/layout-item-selector-api/src/main/java/com/liferay/layout/item/selector/criterion/LayoutItemSelectorCriterion.java
+++ b/modules/apps/layout/layout-item-selector-api/src/main/java/com/liferay/layout/item/selector/criterion/LayoutItemSelectorCriterion.java
@@ -26,24 +26,12 @@ public class LayoutItemSelectorCriterion extends BaseItemSelectorCriterion {
 		return _enableCurrentPage;
 	}
 
-	public boolean isFollowURLOnTitleClick() {
-		return _followURLOnTitleClick;
-	}
-
 	public boolean isMultiSelection() {
 		return _multiSelection;
 	}
 
-	public boolean isShowActionsMenu() {
-		return _showActionsMenu;
-	}
-
 	public boolean isShowBreadcrumb() {
 		return _showBreadcrumb;
-	}
-
-	public boolean isShowDraftPages() {
-		return _showDraftPages;
 	}
 
 	public boolean isShowPrivatePages() {
@@ -62,24 +50,12 @@ public class LayoutItemSelectorCriterion extends BaseItemSelectorCriterion {
 		_enableCurrentPage = enableCurrentPage;
 	}
 
-	public void setFollowURLOnTitleClick(boolean followURLOnTitleClick) {
-		_followURLOnTitleClick = followURLOnTitleClick;
-	}
-
 	public void setMultiSelection(boolean multiSelection) {
 		_multiSelection = multiSelection;
 	}
 
-	public void setShowActionsMenu(boolean showActionsMenu) {
-		_showActionsMenu = showActionsMenu;
-	}
-
 	public void setShowBreadcrumb(boolean showBreadcrumb) {
 		_showBreadcrumb = showBreadcrumb;
-	}
-
-	public void setShowDraftPages(boolean showDraftPages) {
-		_showDraftPages = showDraftPages;
 	}
 
 	public void setShowPrivatePages(boolean showPrivatePages) {
@@ -92,11 +68,8 @@ public class LayoutItemSelectorCriterion extends BaseItemSelectorCriterion {
 
 	private boolean _checkDisplayPage;
 	private boolean _enableCurrentPage;
-	private boolean _followURLOnTitleClick;
 	private boolean _multiSelection;
-	private boolean _showActionsMenu;
 	private boolean _showBreadcrumb;
-	private boolean _showDraftPages;
 	private boolean _showPrivatePages;
 	private boolean _showPublicPages;
 

--- a/modules/apps/layout/layout-item-selector-api/src/main/resources/com/liferay/layout/item/selector/criterion/packageinfo
+++ b/modules/apps/layout/layout-item-selector-api/src/main/resources/com/liferay/layout/item/selector/criterion/packageinfo
@@ -1,1 +1,1 @@
-version 1.4.0
+version 2.0.0

--- a/modules/apps/layout/layout-item-selector-web/src/main/java/com/liferay/layout/item/selector/web/internal/display/context/LayoutItemSelectorViewDisplayContext.java
+++ b/modules/apps/layout/layout-item-selector-web/src/main/java/com/liferay/layout/item/selector/web/internal/display/context/LayoutItemSelectorViewDisplayContext.java
@@ -97,10 +97,6 @@ public class LayoutItemSelectorViewDisplayContext {
 		return _layoutItemSelectorCriterion.isEnableCurrentPage();
 	}
 
-	public boolean isFollowURLOnTitleClick() {
-		return _layoutItemSelectorCriterion.isFollowURLOnTitleClick();
-	}
-
 	public boolean isMultiSelection() {
 		return _layoutItemSelectorCriterion.isMultiSelection();
 	}
@@ -111,14 +107,6 @@ public class LayoutItemSelectorViewDisplayContext {
 
 	public boolean isShowBreadcrumb() {
 		return _layoutItemSelectorCriterion.isShowBreadcrumb();
-	}
-
-	public boolean isShowDraftPages() {
-		return _layoutItemSelectorCriterion.isShowDraftPages();
-	}
-
-	public boolean isShowHiddenPages() {
-		return _layoutItemSelectorCriterion.isShowHiddenPages();
 	}
 
 	private BreadcrumbEntry _getHomeBreadcrumbEntry() throws PortalException {

--- a/modules/apps/layout/layout-item-selector-web/src/main/resources/META-INF/resources/layouts.jsp
+++ b/modules/apps/layout/layout-item-selector-web/src/main/resources/META-INF/resources/layouts.jsp
@@ -22,12 +22,9 @@ LayoutItemSelectorViewDisplayContext layoutItemSelectorViewDisplayContext = (Lay
 <liferay-layout:select-layout
 	checkDisplayPage="<%= layoutItemSelectorViewDisplayContext.isCheckDisplayPage() %>"
 	enableCurrentPage="<%= layoutItemSelectorViewDisplayContext.isEnableCurrentPage() %>"
-	followURLOnTitleClick="<%= layoutItemSelectorViewDisplayContext.isFollowURLOnTitleClick() %>"
 	itemSelectorReturnType="<%= layoutItemSelectorViewDisplayContext.getItemSelectedReturnType() %>"
 	itemSelectorSaveEvent="<%= layoutItemSelectorViewDisplayContext.getItemSelectedEventName() %>"
 	multiSelection="<%= layoutItemSelectorViewDisplayContext.isMultiSelection() %>"
 	namespace="<%= liferayPortletResponse.getNamespace() %>"
 	privateLayout="<%= layoutItemSelectorViewDisplayContext.isPrivateLayout() %>"
-	showDraftLayouts="<%= layoutItemSelectorViewDisplayContext.isShowDraftPages() %>"
-	showHiddenLayouts="<%= layoutItemSelectorViewDisplayContext.isShowHiddenPages() %>"
 />

--- a/modules/apps/layout/layout-taglib/bnd.bnd
+++ b/modules/apps/layout/layout-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Layout Taglib
 Bundle-SymbolicName: com.liferay.layout.taglib
-Bundle-Version: 15.0.3
+Bundle-Version: 16.0.0
 Export-Package:\
 	com.liferay.layout.taglib.servlet.taglib,\
 	com.liferay.layout.taglib.servlet.taglib.react,\

--- a/modules/apps/layout/layout-taglib/package.json
+++ b/modules/apps/layout/layout-taglib/package.json
@@ -8,5 +8,5 @@
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "15.0.3"
+	"version": "16.0.0"
 }

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/struts/GetLayoutsTreeStrutsAction.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/struts/GetLayoutsTreeStrutsAction.java
@@ -1,0 +1,102 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.taglib.internal.struts;
+
+import com.liferay.layout.taglib.internal.util.LayoutsUtil;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.service.LayoutService;
+import com.liferay.portal.kernel.servlet.ServletResponseUtil;
+import com.liferay.portal.kernel.struts.StrutsAction;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.util.PropsValues;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Eudaldo Alonso
+ */
+@Component(
+	property = "path=/portal/get_layouts", service = StrutsAction.class
+)
+public class GetLayoutsTreeStrutsAction implements StrutsAction {
+
+	@Override
+	public String execute(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws Exception {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		long groupId = ParamUtil.getLong(
+			httpServletRequest, "groupId", themeDisplay.getScopeGroupId());
+
+		boolean checkDisplayPage = ParamUtil.getBoolean(
+			httpServletRequest, "checkDisplayPage");
+		boolean privateLayout = ParamUtil.getBoolean(
+			httpServletRequest, "privateLayout");
+		long parentLayoutId = ParamUtil.getLong(
+			httpServletRequest, "parentLayoutId");
+		String itemSelectorReturnType = ParamUtil.getString(
+			httpServletRequest, "itemSelectorReturnType");
+		String[] selectedLayoutUuids = ParamUtil.getStringValues(
+			httpServletRequest, "layoutUuid");
+
+		ServletResponseUtil.write(
+			httpServletResponse,
+			JSONUtil.put(
+				"hasMoreElements",
+				() -> {
+					int childLayoutsCount = _layoutService.getLayoutsCount(
+						groupId, privateLayout, parentLayoutId);
+
+					int start = ParamUtil.getInteger(
+						httpServletRequest, "start");
+
+					start = Math.max(0, start);
+
+					int pageSize = GetterUtil.getInteger(
+						PropsValues.LAYOUT_MANAGE_PAGES_INITIAL_CHILDREN);
+
+					int end = ParamUtil.getInteger(
+						httpServletRequest, "end", start + pageSize);
+
+					end = Math.max(start, end);
+
+					if (childLayoutsCount > end) {
+						return true;
+					}
+
+					return false;
+				}
+			).put(
+				"items",
+				LayoutsUtil.getLayoutsJSONArray(
+					checkDisplayPage, groupId, httpServletRequest,
+					itemSelectorReturnType, parentLayoutId, privateLayout,
+					selectedLayoutUuids)
+			).toString());
+
+		return null;
+	}
+
+	@Reference
+	private JSONFactory _jsonFactory;
+
+	@Reference
+	private LayoutService _layoutService;
+
+}

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/util/LayoutsUtil.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/util/LayoutsUtil.java
@@ -1,0 +1,196 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.taglib.internal.util;
+
+import com.liferay.item.selector.criteria.UUIDItemSelectorReturnType;
+import com.liferay.layout.item.selector.LayoutItemSelectorReturnType;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
+import com.liferay.portal.kernel.security.auth.AuthTokenUtil;
+import com.liferay.portal.kernel.service.LayoutServiceUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.Constants;
+import com.liferay.portal.kernel.util.HttpComponentsUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.util.PropsValues;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * @author Eudaldo Alonso
+ */
+public class LayoutsUtil {
+
+	public static JSONArray getLayoutsJSONArray(
+			boolean checkDisplayPage, long groupId, HttpServletRequest httpServletRequest,
+			String itemSelectorReturnType, long parentLayoutId, boolean privateLayout,
+			String[] selectedLayoutUuids)
+		throws Exception {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
+
+		List<Layout> layouts = LayoutServiceUtil.getLayouts(
+			groupId, privateLayout, parentLayoutId, false, 0,
+			PropsValues.LAYOUT_MANAGE_PAGES_INITIAL_CHILDREN);
+
+		for (Layout layout : layouts) {
+			if (_isExcludedLayout(layout)) {
+				continue;
+			}
+
+			int childLayoutsCount = LayoutServiceUtil.getLayoutsCount(
+				groupId, privateLayout, parentLayoutId);
+
+			JSONArray childLayoutsJSONArray = getLayoutsJSONArray(
+				checkDisplayPage, groupId, httpServletRequest,
+				itemSelectorReturnType, layout.getLayoutId(), privateLayout,
+				selectedLayoutUuids);
+
+			jsonArray.put(
+				JSONUtil.put(
+					"children", childLayoutsJSONArray
+				).put(
+					"disabled",
+					() -> {
+						if ((checkDisplayPage &&
+							 !layout.isContentDisplayPage()) ||
+							(checkDisplayPage &&
+							 (layout.getPlid() == _getSelPlid(httpServletRequest)))) {
+
+							return true;
+						}
+
+						return null;
+					}
+				).put(
+					"groupId", layout.getGroupId()
+				).put(
+					"hasChildren", childLayoutsCount > 0
+				).put(
+					"icon", layout.getIcon()
+				).put(
+					"id", layout.getUuid()
+				).put(
+					"layoutId", layout.getLayoutId()
+				).put(
+					"name", layout.getName(themeDisplay.getLocale())
+				).put(
+					"paginated",
+					() -> {
+						if (childLayoutsCount >
+							childLayoutsJSONArray.length()) {
+
+							return true;
+						}
+
+						return null;
+					}
+				).put(
+					"payload", _getPayload(httpServletRequest, itemSelectorReturnType, layout, themeDisplay)
+				).put(
+					"privateLayout", layout.isPrivateLayout()
+				).put(
+					"returnType", itemSelectorReturnType
+				).put(
+					"selected",
+					() -> {
+						if (ArrayUtil.contains(
+								selectedLayoutUuids, layout.getUuid())) {
+
+							return true;
+						}
+
+						return false;
+					}
+				).put(
+					"url",
+					PortalUtil.getLayoutRelativeURL(layout, themeDisplay, false)
+				).put(
+					"value", layout.getBreadcrumb(themeDisplay.getLocale())
+				));
+		}
+
+		return jsonArray;
+	}
+
+	private static String _getPayload(
+			HttpServletRequest httpServletRequest, String itemSelectorReturnType, Layout layout,
+			ThemeDisplay themeDisplay)
+		throws Exception {
+
+		if (Objects.equals(
+			LayoutItemSelectorReturnType.class.getName(),
+			itemSelectorReturnType)) {
+
+			return JSONUtil.put(
+				"layoutId", layout.getLayoutId()
+			).put(
+				"name", layout.getName(themeDisplay.getLocale())
+			).put(
+				"plid", layout.getPlid()
+			).put(
+				"previewURL",
+				() -> {
+					String layoutURL = HttpComponentsUtil.addParameter(
+						PortalUtil.getLayoutFullURL(layout, themeDisplay),
+						"p_l_mode", Constants.PREVIEW);
+
+					return HttpComponentsUtil.addParameter(
+						layoutURL, "p_p_auth",
+						AuthTokenUtil.getToken(httpServletRequest));
+				}
+			).put(
+				"private", layout.isPrivateLayout()
+			).put(
+				"url", PortalUtil.getLayoutFullURL(layout, themeDisplay)
+			).put(
+				"uuid", layout.getUuid()
+			).toString();
+		}
+		else if (Objects.equals(
+			UUIDItemSelectorReturnType.class.getName(),
+			itemSelectorReturnType)) {
+
+			return layout.getUuid();
+		}
+
+		return PortalUtil.getLayoutRelativeURL(layout, themeDisplay, false);
+	}
+
+	private static long _getSelPlid(HttpServletRequest httpServletRequest) {
+		return ParamUtil.getLong(
+			httpServletRequest, "selPlid", LayoutConstants.DEFAULT_PLID);
+	}
+
+	private static boolean _isExcludedLayout(Layout layout) {
+		if (!layout.isTypeContent()) {
+			return false;
+		}
+
+		if (layout.fetchDraftLayout() != null) {
+			return !layout.isPublished();
+		}
+
+		if (layout.isApproved() && !layout.isHidden() && !layout.isSystem()) {
+			return false;
+		}
+
+		return true;
+	}
+
+}

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/react/SelectLayoutTag.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/react/SelectLayoutTag.java
@@ -5,10 +5,10 @@
 
 package com.liferay.layout.taglib.servlet.taglib.react;
 
-import com.liferay.exportimport.kernel.staging.StagingUtil;
 import com.liferay.item.selector.criteria.UUIDItemSelectorReturnType;
 import com.liferay.layout.item.selector.LayoutItemSelectorReturnType;
 import com.liferay.layout.taglib.internal.servlet.ServletContextUtil;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -200,12 +200,13 @@ public class SelectLayoutTag extends IncludeTag {
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
 		List<Layout> layouts = LayoutServiceUtil.getLayouts(
-			groupId, privateLayout, parentLayoutId);
+			groupId, privateLayout, parentLayoutId, false, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS);
 
 		// Creo que aquí es donde habría que paginar
 
 		for (Layout layout : layouts) {
-			if (_isExcludedLayout(layout) || StagingUtil.isIncomplete(layout)) {
+			if (_isExcludedLayout(layout)) {
 				continue;
 			}
 

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/react/SelectLayoutTag.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/react/SelectLayoutTag.java
@@ -23,11 +23,13 @@ import com.liferay.portal.kernel.service.LayoutServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Constants;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.util.PropsValues;
 import com.liferay.taglib.util.IncludeTag;
 
 import java.util.List;
@@ -205,11 +207,32 @@ public class SelectLayoutTag extends IncludeTag {
 		}
 	}
 
+	private Map<String, Object> _getConfigData() {
+		return HashMapBuilder.<String, Object>put(
+			"loadMoreItemsURL",
+			() -> {
+				HttpServletRequest httpServletRequest = getRequest();
+
+				ThemeDisplay themeDisplay =
+					(ThemeDisplay)httpServletRequest.getAttribute(
+						WebKeys.THEME_DISPLAY);
+
+				return themeDisplay.getPathMain() + "/portal/get_layouts_tree";
+			}
+		).put(
+			"maxPageSize",
+			GetterUtil.getInteger(
+				PropsValues.LAYOUT_MANAGE_PAGES_INITIAL_CHILDREN)
+		).build();
+	}
+
 	private Map<String, Object> _getData() throws Exception {
 		String[] selectedLayoutIds = ParamUtil.getStringValues(
 			getRequest(), "layoutUuid");
 
 		return HashMapBuilder.<String, Object>put(
+			"config", this::_getConfigData
+		).put(
 			"followURLOnTitleClick", _followURLOnTitleClick
 		).put(
 			"itemSelectorSaveEvent", _itemSelectorSaveEvent

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/react/SelectLayoutTag.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/react/SelectLayoutTag.java
@@ -45,10 +45,6 @@ import javax.servlet.jsp.PageContext;
  */
 public class SelectLayoutTag extends IncludeTag {
 
-	public boolean getFollowURLOnTitleClick() {
-		return _followURLOnTitleClick;
-	}
-
 	public String getItemSelectorReturnType() {
 		return _itemSelectorReturnType;
 	}
@@ -85,10 +81,6 @@ public class SelectLayoutTag extends IncludeTag {
 		_enableCurrentPage = enableCurrentPage;
 	}
 
-	public void setFollowURLOnTitleClick(boolean followURLOnTitleClick) {
-		_followURLOnTitleClick = followURLOnTitleClick;
-	}
-
 	public void setItemSelectorReturnType(String itemSelectorReturnType) {
 		_itemSelectorReturnType = itemSelectorReturnType;
 	}
@@ -122,7 +114,6 @@ public class SelectLayoutTag extends IncludeTag {
 
 		_checkDisplayPage = false;
 		_enableCurrentPage = false;
-		_followURLOnTitleClick = false;
 		_itemSelectorReturnType = null;
 		_itemSelectorSaveEvent = null;
 		_multiSelection = false;
@@ -171,8 +162,6 @@ public class SelectLayoutTag extends IncludeTag {
 
 		return HashMapBuilder.<String, Object>put(
 			"config", this::_getConfigData
-		).put(
-			"followURLOnTitleClick", _followURLOnTitleClick
 		).put(
 			"itemSelectorSaveEvent", _itemSelectorSaveEvent
 		).put(
@@ -383,7 +372,6 @@ public class SelectLayoutTag extends IncludeTag {
 
 	private boolean _checkDisplayPage;
 	private boolean _enableCurrentPage;
-	private boolean _followURLOnTitleClick;
 	private String _itemSelectorReturnType;
 	private String _itemSelectorSaveEvent;
 	private boolean _multiSelection;

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/react/SelectLayoutTag.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/react/SelectLayoutTag.java
@@ -5,35 +5,25 @@
 
 package com.liferay.layout.taglib.servlet.taglib.react;
 
-import com.liferay.item.selector.criteria.UUIDItemSelectorReturnType;
-import com.liferay.layout.item.selector.LayoutItemSelectorReturnType;
 import com.liferay.layout.taglib.internal.servlet.ServletContextUtil;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.layout.taglib.internal.util.LayoutsUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
-import com.liferay.portal.kernel.security.auth.AuthTokenUtil;
 import com.liferay.portal.kernel.service.LayoutServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
-import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.taglib.util.IncludeTag;
 
-import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.jsp.PageContext;
@@ -146,7 +136,7 @@ public class SelectLayoutTag extends IncludeTag {
 					(ThemeDisplay)httpServletRequest.getAttribute(
 						WebKeys.THEME_DISPLAY);
 
-				return themeDisplay.getPathMain() + "/portal/get_layouts_tree";
+				return themeDisplay.getPathMain() + "/portal/get_layouts";
 			}
 		).put(
 			"maxPageSize",
@@ -174,113 +164,6 @@ public class SelectLayoutTag extends IncludeTag {
 		).build();
 	}
 
-	private JSONArray _getLayoutsJSONArray(
-			long groupId, boolean privateLayout, long parentLayoutId,
-			String[] selectedLayoutUuid)
-		throws Exception {
-
-		HttpServletRequest httpServletRequest = getRequest();
-
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)httpServletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
-
-		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
-
-		List<Layout> layouts = LayoutServiceUtil.getLayouts(
-			groupId, privateLayout, parentLayoutId, false, QueryUtil.ALL_POS,
-			QueryUtil.ALL_POS);
-
-		// Creo que aquí es donde habría que paginar
-
-		for (Layout layout : layouts) {
-			if (_isExcludedLayout(layout)) {
-				continue;
-			}
-
-			jsonArray.put(
-				JSONUtil.put(
-					"children",
-					() -> {
-						JSONArray childrenJSONArray = _getLayoutsJSONArray(
-							groupId, privateLayout, layout.getLayoutId(),
-							selectedLayoutUuid);
-
-						if (childrenJSONArray.length() > 0) {
-							return childrenJSONArray;
-						}
-
-						return null;
-					}
-				).put(
-					"disabled",
-					() -> {
-						if ((_checkDisplayPage &&
-							 !layout.isContentDisplayPage()) ||
-							(_enableCurrentPage &&
-							 (layout.getPlid() == _getSelPlid()))) {
-
-							return true;
-						}
-
-						return null;
-					}
-				).put(
-					"groupId", layout.getGroupId()
-				).put(
-					"hasChildren", layout.hasChildren()
-				).put(
-					"icon", layout.getIcon()
-				).put(
-					"id", layout.getUuid()
-				).put(
-					"layoutId", layout.getLayoutId()
-				).put(
-					"name", layout.getName(themeDisplay.getLocale())
-				).put(
-					"paginated",
-					() -> {
-						int layoutsCount = LayoutServiceUtil.getLayoutsCount(
-							groupId, layout.isPrivateLayout(),
-							LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
-
-						if (layoutsCount >
-								PropsValues.
-									LAYOUT_MANAGE_PAGES_INITIAL_CHILDREN) {
-
-							return true;
-						}
-
-						return false;
-					}
-				).put(
-					"payload", _getPayload(layout, themeDisplay)
-				).put(
-					"privateLayout", layout.isPrivateLayout()
-				).put(
-					"returnType", getItemSelectorReturnType()
-				).put(
-					"selected",
-					() -> {
-						if (ArrayUtil.contains(
-								selectedLayoutUuid, layout.getUuid())) {
-
-							return true;
-						}
-
-						return false;
-					}
-				).put(
-					"url",
-					PortalUtil.getLayoutRelativeURL(layout, themeDisplay, false)
-				).put(
-					"value", layout.getBreadcrumb(themeDisplay.getLocale())
-				));
-		}
-
-		return jsonArray;
-	}
-
 	private JSONArray _getLayoutsJSONArray(String[] selectedLayoutIds)
 		throws Exception {
 
@@ -301,8 +184,10 @@ public class SelectLayoutTag extends IncludeTag {
 		return JSONUtil.put(
 			JSONUtil.put(
 				"children",
-				_getLayoutsJSONArray(
-					themeDisplay.getScopeGroupId(), _privateLayout, 0,
+				LayoutsUtil.getLayoutsJSONArray(
+					_checkDisplayPage, themeDisplay.getScopeGroupId(),
+					httpServletRequest, _itemSelectorReturnType,
+					LayoutConstants.DEFAULT_PARENT_LAYOUT_ID, _privateLayout,
 					selectedLayoutIds)
 			).put(
 				"disabled", true
@@ -311,73 +196,26 @@ public class SelectLayoutTag extends IncludeTag {
 			).put(
 				"icon", "home"
 			).put(
+				"paginated",
+				() -> {
+					int layoutsCount = LayoutServiceUtil.getLayoutsCount(
+						themeDisplay.getScopeGroupId(), _privateLayout,
+						LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
+
+					if (layoutsCount >
+							PropsValues.
+								LAYOUT_MANAGE_PAGES_INITIAL_CHILDREN) {
+
+						return true;
+					}
+
+					return false;
+				}
+			).put(
 				"id", "0"
 			).put(
 				"name", themeDisplay.getScopeGroupName()
 			));
-	}
-
-	private String _getPayload(Layout layout, ThemeDisplay themeDisplay)
-		throws Exception {
-
-		if (Objects.equals(
-				LayoutItemSelectorReturnType.class.getName(),
-				getItemSelectorReturnType())) {
-
-			return JSONUtil.put(
-				"layoutId", layout.getLayoutId()
-			).put(
-				"name", layout.getName(themeDisplay.getLocale())
-			).put(
-				"plid", layout.getPlid()
-			).put(
-				"previewURL",
-				() -> {
-					String layoutURL = HttpComponentsUtil.addParameter(
-						PortalUtil.getLayoutFullURL(layout, themeDisplay),
-						"p_l_mode", Constants.PREVIEW);
-
-					return HttpComponentsUtil.addParameter(
-						layoutURL, "p_p_auth",
-						AuthTokenUtil.getToken(getRequest()));
-				}
-			).put(
-				"private", layout.isPrivateLayout()
-			).put(
-				"url", PortalUtil.getLayoutFullURL(layout, themeDisplay)
-			).put(
-				"uuid", layout.getUuid()
-			).toString();
-		}
-		else if (Objects.equals(
-					UUIDItemSelectorReturnType.class.getName(),
-					getItemSelectorReturnType())) {
-
-			return layout.getUuid();
-		}
-
-		return PortalUtil.getLayoutRelativeURL(layout, themeDisplay, false);
-	}
-
-	private long _getSelPlid() {
-		return ParamUtil.getLong(
-			getRequest(), "selPlid", LayoutConstants.DEFAULT_PLID);
-	}
-
-	private boolean _isExcludedLayout(Layout layout) {
-		if (!layout.isTypeContent()) {
-			return false;
-		}
-
-		if (layout.fetchDraftLayout() != null) {
-			return !layout.isPublished();
-		}
-
-		if (layout.isApproved() && !layout.isHidden() && !layout.isSystem()) {
-			return false;
-		}
-
-		return true;
 	}
 
 	private static final String _PAGE = "/select_layout/page.jsp";

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/react/SelectLayoutTag.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/react/SelectLayoutTag.java
@@ -263,6 +263,8 @@ public class SelectLayoutTag extends IncludeTag {
 		List<Layout> layouts = LayoutServiceUtil.getLayouts(
 			groupId, privateLayout, parentLayoutId);
 
+		// Creo que aquí es donde habría que paginar
+
 		for (Layout layout : layouts) {
 			if ((layout.isHidden() && !_showHiddenLayouts) ||
 				_isExcludedLayout(layout) || StagingUtil.isIncomplete(layout)) {
@@ -289,6 +291,8 @@ public class SelectLayoutTag extends IncludeTag {
 			jsonObject.put(
 				"groupId", layout.getGroupId()
 			).put(
+				"hasChildren", layout.hasChildren()
+			).put(
 				"icon", layout.getIcon()
 			).put(
 				"id", layout.getUuid()
@@ -296,6 +300,21 @@ public class SelectLayoutTag extends IncludeTag {
 				"layoutId", layout.getLayoutId()
 			).put(
 				"name", layout.getName(themeDisplay.getLocale())
+			).put(
+				"paginated",
+				() -> {
+					int layoutsCount = LayoutServiceUtil.getLayoutsCount(
+						groupId, layout.isPrivateLayout(),
+						LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
+
+					if (layoutsCount >
+							PropsValues.LAYOUT_MANAGE_PAGES_INITIAL_CHILDREN) {
+
+						return true;
+					}
+
+					return false;
+				}
 			).put(
 				"payload", _getPayload(layout, themeDisplay)
 			).put(

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/react/SelectLayoutTag.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/react/SelectLayoutTag.java
@@ -11,7 +11,6 @@ import com.liferay.layout.taglib.internal.servlet.ServletContextUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
-import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -199,68 +198,84 @@ public class SelectLayoutTag extends IncludeTag {
 				continue;
 			}
 
-			JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
+			jsonArray.put(
+				JSONUtil.put(
+					"children",
+					() -> {
+						JSONArray childrenJSONArray = _getLayoutsJSONArray(
+							groupId, privateLayout, layout.getLayoutId(),
+							selectedLayoutUuid);
 
-			JSONArray childrenJSONArray = _getLayoutsJSONArray(
-				groupId, privateLayout, layout.getLayoutId(),
-				selectedLayoutUuid);
+						if (childrenJSONArray.length() > 0) {
+							return childrenJSONArray;
+						}
 
-			if (childrenJSONArray.length() > 0) {
-				jsonObject.put("children", childrenJSONArray);
-			}
-
-			if ((_checkDisplayPage && !layout.isContentDisplayPage()) ||
-				(_enableCurrentPage && (layout.getPlid() == _getSelPlid()))) {
-
-				jsonObject.put("disabled", true);
-			}
-
-			jsonObject.put(
-				"groupId", layout.getGroupId()
-			).put(
-				"hasChildren", layout.hasChildren()
-			).put(
-				"icon", layout.getIcon()
-			).put(
-				"id", layout.getUuid()
-			).put(
-				"layoutId", layout.getLayoutId()
-			).put(
-				"name", layout.getName(themeDisplay.getLocale())
-			).put(
-				"paginated",
-				() -> {
-					int layoutsCount = LayoutServiceUtil.getLayoutsCount(
-						groupId, layout.isPrivateLayout(),
-						LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
-
-					if (layoutsCount >
-							PropsValues.LAYOUT_MANAGE_PAGES_INITIAL_CHILDREN) {
-
-						return true;
+						return null;
 					}
+				).put(
+					"disabled",
+					() -> {
+						if ((_checkDisplayPage &&
+							 !layout.isContentDisplayPage()) ||
+							(_enableCurrentPage &&
+							 (layout.getPlid() == _getSelPlid()))) {
 
-					return false;
-				}
-			).put(
-				"payload", _getPayload(layout, themeDisplay)
-			).put(
-				"privateLayout", layout.isPrivateLayout()
-			).put(
-				"returnType", getItemSelectorReturnType()
-			).put(
-				"url",
-				PortalUtil.getLayoutRelativeURL(layout, themeDisplay, false)
-			);
+							return true;
+						}
 
-			if (ArrayUtil.contains(selectedLayoutUuid, layout.getUuid())) {
-				jsonObject.put("selected", true);
-			}
+						return null;
+					}
+				).put(
+					"groupId", layout.getGroupId()
+				).put(
+					"hasChildren", layout.hasChildren()
+				).put(
+					"icon", layout.getIcon()
+				).put(
+					"id", layout.getUuid()
+				).put(
+					"layoutId", layout.getLayoutId()
+				).put(
+					"name", layout.getName(themeDisplay.getLocale())
+				).put(
+					"paginated",
+					() -> {
+						int layoutsCount = LayoutServiceUtil.getLayoutsCount(
+							groupId, layout.isPrivateLayout(),
+							LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
 
-			jsonObject.put(
-				"value", layout.getBreadcrumb(themeDisplay.getLocale()));
+						if (layoutsCount >
+								PropsValues.
+									LAYOUT_MANAGE_PAGES_INITIAL_CHILDREN) {
 
-			jsonArray.put(jsonObject);
+							return true;
+						}
+
+						return false;
+					}
+				).put(
+					"payload", _getPayload(layout, themeDisplay)
+				).put(
+					"privateLayout", layout.isPrivateLayout()
+				).put(
+					"returnType", getItemSelectorReturnType()
+				).put(
+					"selected",
+					() -> {
+						if (ArrayUtil.contains(
+								selectedLayoutUuid, layout.getUuid())) {
+
+							return true;
+						}
+
+						return false;
+					}
+				).put(
+					"url",
+					PortalUtil.getLayoutRelativeURL(layout, themeDisplay, false)
+				).put(
+					"value", layout.getBreadcrumb(themeDisplay.getLocale())
+				));
 		}
 
 		return jsonArray;

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/react/SelectLayoutTag.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/react/SelectLayoutTag.java
@@ -45,10 +45,6 @@ import javax.servlet.jsp.PageContext;
  */
 public class SelectLayoutTag extends IncludeTag {
 
-	public String getComponentId() {
-		return _componentId;
-	}
-
 	public boolean getFollowURLOnTitleClick() {
 		return _followURLOnTitleClick;
 	}
@@ -63,22 +59,6 @@ public class SelectLayoutTag extends IncludeTag {
 
 	public String getNamespace() {
 		return _namespace;
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
-	 */
-	@Deprecated
-	public String getPathThemeImages() {
-		return _pathThemeImages;
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
-	 */
-	@Deprecated
-	public String getViewType() {
-		return _viewType;
 	}
 
 	public boolean isCheckDisplayPage() {
@@ -97,20 +77,8 @@ public class SelectLayoutTag extends IncludeTag {
 		return _privateLayout;
 	}
 
-	public boolean isShowDraftLayouts() {
-		return _showDraftLayouts;
-	}
-
-	public boolean isShowHiddenLayouts() {
-		return _showHiddenLayouts;
-	}
-
 	public void setCheckDisplayPage(boolean checkDisplayPage) {
 		_checkDisplayPage = checkDisplayPage;
-	}
-
-	public void setComponentId(String componentId) {
-		_componentId = componentId;
 	}
 
 	public void setEnableCurrentPage(boolean enableCurrentPage) {
@@ -144,32 +112,8 @@ public class SelectLayoutTag extends IncludeTag {
 		setServletContext(ServletContextUtil.getServletContext());
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
-	 */
-	@Deprecated
-	public void setPathThemeImages(String pathThemeImages) {
-		_pathThemeImages = pathThemeImages;
-	}
-
 	public void setPrivateLayout(boolean privateLayout) {
 		_privateLayout = privateLayout;
-	}
-
-	public void setShowDraftLayouts(boolean showDraftLayouts) {
-		_showDraftLayouts = showDraftLayouts;
-	}
-
-	public void setShowHiddenLayouts(boolean showHiddenLayouts) {
-		_showHiddenLayouts = showHiddenLayouts;
-	}
-
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
-	 */
-	@Deprecated
-	public void setViewType(String viewType) {
-		_viewType = viewType;
 	}
 
 	@Override
@@ -177,18 +121,13 @@ public class SelectLayoutTag extends IncludeTag {
 		super.cleanUp();
 
 		_checkDisplayPage = false;
-		_componentId = null;
 		_enableCurrentPage = false;
 		_followURLOnTitleClick = false;
 		_itemSelectorReturnType = null;
 		_itemSelectorSaveEvent = null;
 		_multiSelection = false;
 		_namespace = null;
-		_pathThemeImages = null;
 		_privateLayout = false;
-		_showDraftLayouts = false;
-		_showHiddenLayouts = false;
-		_viewType = null;
 	}
 
 	@Override
@@ -266,9 +205,7 @@ public class SelectLayoutTag extends IncludeTag {
 		// Creo que aquí es donde habría que paginar
 
 		for (Layout layout : layouts) {
-			if ((layout.isHidden() && !_showHiddenLayouts) ||
-				_isExcludedLayout(layout) || StagingUtil.isIncomplete(layout)) {
-
+			if (_isExcludedLayout(layout) || StagingUtil.isIncomplete(layout)) {
 				continue;
 			}
 
@@ -428,10 +365,6 @@ public class SelectLayoutTag extends IncludeTag {
 		}
 
 		if (layout.fetchDraftLayout() != null) {
-			if (_showDraftLayouts) {
-				return false;
-			}
-
 			return !layout.isPublished();
 		}
 
@@ -448,17 +381,12 @@ public class SelectLayoutTag extends IncludeTag {
 		SelectLayoutTag.class);
 
 	private boolean _checkDisplayPage;
-	private String _componentId;
 	private boolean _enableCurrentPage;
 	private boolean _followURLOnTitleClick;
 	private String _itemSelectorReturnType;
 	private String _itemSelectorSaveEvent;
 	private boolean _multiSelection;
 	private String _namespace;
-	private String _pathThemeImages;
 	private boolean _privateLayout;
-	private boolean _showDraftLayouts;
-	private boolean _showHiddenLayouts;
-	private String _viewType;
 
 }

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/liferay-layout.tld
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/liferay-layout.tld
@@ -131,20 +131,7 @@
 		</attribute>
 		<attribute>
 			<description></description>
-			<name>componentId</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<description></description>
 			<name>enableCurrentPage</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-			<type>boolean</type>
-		</attribute>
-		<attribute>
-			<description></description>
-			<name>followURLOnTitleClick</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 			<type>boolean</type>
@@ -175,36 +162,11 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
-			<name>pathThemeImages</name>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<description></description>
 			<name>privateLayout</name>
 			<required>true</required>
 			<rtexprvalue>true</rtexprvalue>
 			<type>boolean</type>
-		</attribute>
-		<attribute>
-			<description></description>
-			<name>showDraftLayouts</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-			<type>boolean</type>
-		</attribute>
-		<attribute>
-			<description></description>
-			<name>showHiddenLayouts</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-			<type>boolean</type>
-		</attribute>
-		<attribute>
-			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
-			<name>viewType</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 	</tag>
 </taglib>

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/select_layout/js/SelectLayout.es.js
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/select_layout/js/SelectLayout.es.js
@@ -23,7 +23,6 @@ import {SelectLayoutTree} from './SelectLayoutTree.es';
 
 const SelectLayout = ({
 	config,
-	followURLOnTitleClick,
 	itemSelectorSaveEvent,
 	multiSelection,
 	namespace,
@@ -85,7 +84,6 @@ const SelectLayout = ({
 					<SelectLayoutTree
 						config={{...config, namespace}}
 						filter={filter}
-						followURLOnTitleClick={followURLOnTitleClick}
 						itemSelectorSaveEvent={itemSelectorSaveEvent}
 						items={nodes}
 						multiSelection={multiSelection}
@@ -112,7 +110,6 @@ const EmptyState = () => {
 };
 
 SelectLayout.propTypes = {
-	followURLOnTitleClick: PropTypes.bool,
 	itemSelectorSaveEvent: PropTypes.string,
 	multiSelection: PropTypes.bool,
 	namespace: PropTypes.string,

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/select_layout/js/SelectLayout.es.js
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/select_layout/js/SelectLayout.es.js
@@ -22,9 +22,11 @@ import {SelectLayoutTree} from './SelectLayoutTree.es';
  */
 
 const SelectLayout = ({
+	config,
 	followURLOnTitleClick,
 	itemSelectorSaveEvent,
 	multiSelection,
+	namespace,
 	nodes,
 	selectedLayoutIds,
 }) => {
@@ -81,6 +83,7 @@ const SelectLayout = ({
 					)}
 
 					<SelectLayoutTree
+						config={{...config, namespace}}
 						filter={filter}
 						followURLOnTitleClick={followURLOnTitleClick}
 						itemSelectorSaveEvent={itemSelectorSaveEvent}

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/select_layout/js/SelectLayoutTree.es.js
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/select_layout/js/SelectLayoutTree.es.js
@@ -3,12 +3,13 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import ClayButton from '@clayui/button';
 import {TreeView as ClayTreeView} from '@clayui/core';
 import ClayEmptyState from '@clayui/empty-state';
 import {ClayCheckbox} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
-import {getOpener, sub} from 'frontend-js-web';
-import React, {useMemo, useRef, useState} from 'react';
+import {fetch, getOpener, openToast, sub} from 'frontend-js-web';
+import React, {useCallback, useMemo, useRef, useState} from 'react';
 
 const nodeByName = (items, name) => {
 	return items.reduce(function reducer(acc, item) {
@@ -26,12 +27,15 @@ const nodeByName = (items, name) => {
 export function SelectLayoutTree({
 	filter,
 	followURLOnTitleClick,
+	config,
 	itemSelectorSaveEvent,
 	items: initialItems = [],
 	onItemsCountChange,
 	multiSelection,
 	selectedLayoutIds,
 }) {
+	const {loadMoreItemsURL, maxPageSize, namespace} = config;
+
 	const [items, setItems] = useState(initialItems);
 
 	const [selectedKeys, setSelectionChange] = useState(
@@ -165,6 +169,46 @@ export function SelectLayoutTree({
 		}
 	};
 
+	const onLoadMore = useCallback(
+		(item) => {
+			if (!item.hasChildren) {
+				return Promise.resolve({
+					cursor: null,
+					items: null,
+				});
+			}
+
+			const cursor = item.children
+				? Math.floor(item.children.length / maxPageSize)
+				: 0;
+
+			return fetch(loadMoreItemsURL, {
+				body: Liferay.Util.objectToURLSearchParams({
+					[`${namespace}parentLayoutId`]: item.layoutId,
+					[`${namespace}redirect`]:
+						window.location.pathname + window.location.search,
+					[`${namespace}start`]: cursor * maxPageSize,
+				}),
+				method: 'post',
+			})
+				.then((response) => response.json())
+				.then(({hasMoreElements, items: nextItems}) => ({
+					cursor: hasMoreElements ? cursor + 1 : null,
+					items: nextItems,
+				}))
+				.catch(() =>
+					openToast({
+						message: Liferay.Language.get(
+							'an-unexpected-error-occurred'
+						),
+						title: Liferay.Language.get('error'),
+						type: 'danger',
+					})
+				);
+		},
+		[loadMoreItemsURL, maxPageSize, namespace]
+	);
+
 	return filteredItems.length ? (
 		<div className="pt-3 px-3">
 			{multiSelection && (
@@ -184,12 +228,13 @@ export function SelectLayoutTree({
 			<ClayTreeView
 				items={filteredItems}
 				onItemsChange={(items) => setItems(items)}
+				onLoadMore={onLoadMore}
 				onSelectionChange={(keys) => setSelectionChange(keys)}
 				selectedKeys={selectedKeys}
 				selectionMode={multiSelection ? 'multiple' : 'single'}
 				showExpanderOnHover={false}
 			>
-				{(item, selection, expand) => (
+				{(item, selection, expand, load) => (
 					<ClayTreeView.Item active={false}>
 						<ClayTreeView.ItemStack
 							active={false}
@@ -266,6 +311,19 @@ export function SelectLayoutTree({
 								</ClayTreeView.Item>
 							)}
 						</ClayTreeView.Group>
+
+						{load.get(item.id) !== null &&
+							expand.has(item.id) &&
+							item.paginated && (
+								<ClayButton
+									borderless
+									className="ml-3 text-light"
+									displayType="secondary"
+									onClick={() => load.loadMore(item.id, item)}
+								>
+									{Liferay.Language.get('load-more-results')}
+								</ClayButton>
+							)}
 					</ClayTreeView.Item>
 				)}
 			</ClayTreeView>

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/select_layout/js/SelectLayoutTree.es.js
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/select_layout/js/SelectLayoutTree.es.js
@@ -26,7 +26,6 @@ const nodeByName = (items, name) => {
 
 export function SelectLayoutTree({
 	filter,
-	followURLOnTitleClick,
 	config,
 	itemSelectorSaveEvent,
 	items: initialItems = [],
@@ -92,20 +91,15 @@ export function SelectLayoutTree({
 			return;
 		}
 
-		if (followURLOnTitleClick) {
-			getOpener().document.location.href = item.url;
-		}
-		else {
-			const data = Array.from(selectedItemsRef.current.values());
+		const data = Array.from(selectedItemsRef.current.values());
 
-			Liferay.fire(itemSelectorSaveEvent, {
-				data,
-			});
+		Liferay.fire(itemSelectorSaveEvent, {
+			data,
+		});
 
-			getOpener().Liferay.fire(itemSelectorSaveEvent, {
-				data,
-			});
-		}
+		getOpener().Liferay.fire(itemSelectorSaveEvent, {
+			data,
+		});
 	};
 
 	const handleSingleSelection = (item, selection) => {
@@ -135,12 +129,6 @@ export function SelectLayoutTree({
 
 	const onClick = (event, item, selection, expand) => {
 		event.preventDefault();
-
-		if (followURLOnTitleClick) {
-			getOpener().document.location.href = item.url;
-
-			return;
-		}
 
 		if (item.disabled) {
 			expand.toggle(item.id);

--- a/modules/apps/layout/layout-taglib/src/main/resources/com/liferay/layout/taglib/servlet/taglib/react/packageinfo
+++ b/modules/apps/layout/layout-taglib/src/main/resources/com/liferay/layout/taglib/servlet/taglib/react/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 2.0.0

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-link-to-page/src/main/java/com/liferay/layout/type/controller/link/to/page/internal/display/context/LinkToPageLayoutTypeControllerDisplayContext.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-link-to-page/src/main/java/com/liferay/layout/type/controller/link/to/page/internal/display/context/LinkToPageLayoutTypeControllerDisplayContext.java
@@ -55,7 +55,6 @@ public class LinkToPageLayoutTypeControllerDisplayContext {
 			new UUIDItemSelectorReturnType());
 		layoutItemSelectorCriterion.setEnableCurrentPage(false);
 		layoutItemSelectorCriterion.setShowBreadcrumb(false);
-		layoutItemSelectorCriterion.setShowHiddenPages(true);
 
 		boolean privateLayout = ParamUtil.getBoolean(
 			_liferayPortletRequest, "privateLayout");

--- a/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/type/LayoutSiteNavigationMenuItemType.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/type/LayoutSiteNavigationMenuItemType.java
@@ -175,7 +175,6 @@ public class LayoutSiteNavigationMenuItemType
 		layoutItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
 			new UUIDItemSelectorReturnType());
 		layoutItemSelectorCriterion.setShowBreadcrumb(false);
-		layoutItemSelectorCriterion.setShowHiddenPages(true);
 		layoutItemSelectorCriterion.setMultiSelection(true);
 
 		return PortletURLBuilder.create(

--- a/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/resources/META-INF/resources/edit_layout.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/resources/META-INF/resources/edit_layout.jsp
@@ -58,7 +58,6 @@ LayoutItemSelectorCriterion layoutItemSelectorCriterion = new LayoutItemSelector
 
 layoutItemSelectorCriterion.setDesiredItemSelectorReturnTypes(new UUIDItemSelectorReturnType());
 layoutItemSelectorCriterion.setShowBreadcrumb(false);
-layoutItemSelectorCriterion.setShowHiddenPages(true);
 
 PortletURL itemSelectorURL = itemSelector.getItemSelectorURL(RequestBackedPortletURLFactoryUtil.create(renderRequest), eventName, layoutItemSelectorCriterion);
 

--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/display/context/EditStyleBookEntryDisplayContext.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/display/context/EditStyleBookEntryDisplayContext.java
@@ -376,7 +376,6 @@ public class EditStyleBookEntryDisplayContext {
 
 				layoutItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
 					new LayoutItemSelectorReturnType());
-				layoutItemSelectorCriterion.setShowHiddenPages(true);
 
 				Group group = _themeDisplay.getScopeGroup();
 


### PR DESCRIPTION
- LPS-181477 Support load more in SelectLayoutTree
- LPS-181477 Get Config from backend and send it to the tree
- LPS-181477 Add config data to context
- LPS-181477 Paginate items and add hasChildren and paginated props
- LPS-181477 showHiddenPages is always set to true
- LPS-181477 Removes unused methods
- LPS-181477 Removes set call since it is always true
- LPS-181477 The default value of ShowPrivatePages and ShowPublicPages is true by default
- LPS-181477 Clean unused taglib attributes, also removes attributes that have always the same value like _showDraftLayouts = false and _showHiddenLayouts = true
- LPS-181477 Don't include incomplete layouts
- LPS-181477 baseline
- LPS-181477 Clean unused taglib attributes, also removes attributes that have always the same value like _showDraftLayouts = false and _showHiddenLayouts = true
- LPS-181477 Inline
- LPS-X wip
