### PR TITLE
LPD 23768

### DIFF
--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/form/InfoForm.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/form/InfoForm.java
@@ -8,6 +8,7 @@ package com.liferay.info.form;
 import com.liferay.info.field.InfoField;
 import com.liferay.info.field.InfoFieldSet;
 import com.liferay.info.field.InfoFieldSetEntry;
+import com.liferay.info.item.InfoItemRelationship;
 import com.liferay.info.localized.InfoLocalizedValue;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.lang.HashUtil;
@@ -73,6 +74,10 @@ public class InfoForm {
 		}
 
 		return _builder._infoFieldsByName.get(name);
+	}
+
+	public List<InfoItemRelationship> getInfoFieldRelationships() {
+		return new ArrayList<>(_builder._infoFieldRelationships.values());
 	}
 
 	public List<InfoFieldSetEntry> getInfoFieldSetEntries() {
@@ -204,6 +209,20 @@ public class InfoForm {
 			return this;
 		}
 
+		public Builder relationships(
+			List<InfoItemRelationship> infoFieldRelationships) {
+
+			for (InfoItemRelationship infoFieldRelationship :
+					infoFieldRelationships) {
+
+				_infoFieldRelationships.put(
+					infoFieldRelationship.getClassName(),
+					infoFieldRelationship);
+			}
+
+			return this;
+		}
+
 		private void _populateInfoFieldsMaps(
 			InfoFieldSetEntry infoFieldSetEntry) {
 
@@ -231,6 +250,8 @@ public class InfoForm {
 		}
 
 		private InfoLocalizedValue<String> _descriptionInfoLocalizedValue;
+		private final Map<String, InfoItemRelationship>
+			_infoFieldRelationships = new LinkedHashMap<>();
 		private final Map<String, InfoField<?>> _infoFieldsByName =
 			new LinkedHashMap<>();
 		private final Map<String, InfoField<?>> _infoFieldsByUniqueId =

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/item/InfoItemRelationship.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/item/InfoItemRelationship.java
@@ -1,0 +1,60 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.info.item;
+
+import com.liferay.info.localized.InfoLocalizedValue;
+
+import java.util.Locale;
+
+/**
+ * @author Eudaldo alonso
+ */
+public class InfoItemRelationship {
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public String getClassName() {
+		return _builder._className;
+	}
+
+	public String getLabel(Locale locale) {
+		return _builder._labelInfoLocalizedValue.getValue(locale);
+	}
+
+	public static class Builder {
+
+		public InfoItemRelationship build() {
+			return new InfoItemRelationship(this);
+		}
+
+		public Builder className(String className) {
+			_className = className;
+
+			return this;
+		}
+
+		public Builder labelInfoLocalizedValue(
+			InfoLocalizedValue<String> labelInfoLocalizedValue) {
+
+			_labelInfoLocalizedValue = labelInfoLocalizedValue;
+
+			return this;
+		}
+
+		private String _className;
+		private InfoLocalizedValue<String> _labelInfoLocalizedValue;
+
+	}
+
+	private InfoItemRelationship(Builder builder) {
+		_builder = builder;
+	}
+
+	private final Builder _builder;
+
+}

--- a/modules/apps/info/info-api/src/main/resources/com/liferay/info/form/packageinfo
+++ b/modules/apps/info/info-api/src/main/resources/com/liferay/info/form/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 2.2.0

--- a/modules/apps/info/info-api/src/main/resources/com/liferay/info/item/packageinfo
+++ b/modules/apps/info/info-api/src/main/resources/com/liferay/info/item/packageinfo
@@ -1,1 +1,1 @@
-version 7.0.0
+version 7.1.0

--- a/modules/apps/info/info-field-item-selector-web/src/main/java/com/liferay/info/field/item/selector/web/internal/InfoFieldItemSelectorViewDescriptor.java
+++ b/modules/apps/info/info-field-item-selector-web/src/main/java/com/liferay/info/field/item/selector/web/internal/InfoFieldItemSelectorViewDescriptor.java
@@ -7,6 +7,7 @@ package com.liferay.info.field.item.selector.web.internal;
 
 import com.liferay.info.field.InfoField;
 import com.liferay.info.form.InfoForm;
+import com.liferay.info.item.InfoItemRelationship;
 import com.liferay.info.item.InfoItemServiceRegistry;
 import com.liferay.info.item.provider.InfoItemFormProvider;
 import com.liferay.item.selector.ItemSelectorReturnType;
@@ -23,6 +24,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
+import java.util.Collections;
 import java.util.List;
 
 import javax.portlet.PortletRequest;
@@ -68,6 +70,7 @@ public class InfoFieldItemSelectorViewDescriptor
 		return new UUIDItemSelectorReturnType();
 	}
 
+	@Override
 	public SearchContainer<InfoField<?>> getSearchContainer()
 		throws PortalException {
 
@@ -78,29 +81,15 @@ public class InfoFieldItemSelectorViewDescriptor
 		SearchContainer<InfoField<?>> searchContainer = new SearchContainer<>(
 			portletRequest, _portletURL, null, "there-are-no-info-fields");
 
-		String itemType = ParamUtil.getString(_httpServletRequest, "itemType");
-
-		InfoItemFormProvider<?> infoItemFormProvider =
-			_infoItemServiceRegistry.getFirstInfoItemService(
-				InfoItemFormProvider.class, itemType);
-
-		if (infoItemFormProvider == null) {
-			return searchContainer;
-		}
-
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)_httpServletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
-
-		InfoForm infoForm = infoItemFormProvider.getInfoForm(
-			itemType, themeDisplay.getScopeGroupId());
-
-		List<InfoField<?>> infoFields = ListUtil.filter(
-			infoForm.getAllInfoFields(), InfoField::isEditable);
+		List<InfoField<?>> infoFields = _getAllInfoFields();
 
 		String keywords = ParamUtil.getString(_httpServletRequest, "keywords");
 
 		if (Validator.isNotNull(keywords)) {
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)_httpServletRequest.getAttribute(
+					WebKeys.THEME_DISPLAY);
+
 			infoFields = ListUtil.filter(
 				infoFields,
 				infoField -> {
@@ -134,6 +123,42 @@ public class InfoFieldItemSelectorViewDescriptor
 	@Override
 	public boolean isShowSearch() {
 		return true;
+	}
+
+	private List<InfoField<?>> _getAllInfoFields() {
+		String itemType = ParamUtil.getString(_httpServletRequest, "itemType");
+
+		InfoItemFormProvider<?> infoItemFormProvider =
+			_infoItemServiceRegistry.getFirstInfoItemService(
+				InfoItemFormProvider.class, itemType);
+
+		if (infoItemFormProvider == null) {
+			return Collections.emptyList();
+		}
+
+		InfoForm infoForm = infoItemFormProvider.getInfoForm();
+
+		List<InfoField<?>> infoFields = ListUtil.filter(
+			infoForm.getAllInfoFields(), InfoField::isEditable);
+
+		for (InfoItemRelationship infoItemRelationship :
+				infoForm.getInfoFieldRelationships()) {
+
+			InfoItemFormProvider<?> infoItemRelationshipInfoItemFormProvider =
+				_infoItemServiceRegistry.getFirstInfoItemService(
+					InfoItemFormProvider.class,
+					infoItemRelationship.getClassName());
+
+			InfoForm infoFieldRelationshipInfoForm =
+				infoItemRelationshipInfoItemFormProvider.getInfoForm();
+
+			infoFields.addAll(
+				ListUtil.filter(
+					infoFieldRelationshipInfoForm.getAllInfoFields(),
+					InfoField::isEditable));
+		}
+
+		return infoFields;
 	}
 
 	private final HttpServletRequest _httpServletRequest;

--- a/modules/apps/item-selector/item-selector-api/src/main/java/com/liferay/item/selector/ItemSelectorViewDescriptor.java
+++ b/modules/apps/item-selector/item-selector-api/src/main/java/com/liferay/item/selector/ItemSelectorViewDescriptor.java
@@ -10,6 +10,7 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.VerticalCard;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItem;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.search.ResultRowSplitter;
 import com.liferay.portal.kernel.dao.search.RowChecker;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -52,6 +53,10 @@ public interface ItemSelectorViewDescriptor<T> {
 	}
 
 	public default String[] getOrderByKeys() {
+		return null;
+	}
+
+	public default ResultRowSplitter getResultRowSplitter() {
 		return null;
 	}
 

--- a/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_item_selector_view_descriptor.jsp
+++ b/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_item_selector_view_descriptor.jsp
@@ -193,6 +193,7 @@ SearchContainer<Object> searchContainer = itemSelectorViewDescriptorRendererDisp
 		<liferay-ui:search-iterator
 			displayStyle="<%= itemSelectorViewDescriptorRendererDisplayContext.getDisplayStyle() %>"
 			markupView="lexicon"
+			resultRowSplitter="<%= itemSelectorViewDescriptor.getResultRowSplitter() %>"
 			searchContainer="<%= searchContainer %>"
 		/>
 	</liferay-ui:search-container>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -503,6 +503,11 @@ public class ContentPageEditorDisplayContext {
 				_getResourceURL(
 					"/layout_content_page_editor/get_info_item_field_value")
 			).put(
+				"getInfoItemOneToManyRelationshipsURL",
+				_getResourceURL(
+					"/layout_content_page_editor" +
+						"/get_info_item_one_to_many_relationship")
+			).put(
 				"getLayoutFriendlyURL",
 				_getResourceURL(
 					"/layout_content_page_editor/get_layout_friendly_url")

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetInfoItemOneToManyRelationshipMVCResourceCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetInfoItemOneToManyRelationshipMVCResourceCommand.java
@@ -1,0 +1,86 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.content.page.editor.web.internal.portlet.action;
+
+import com.liferay.info.form.InfoForm;
+import com.liferay.info.item.InfoItemRelationship;
+import com.liferay.info.item.InfoItemServiceRegistry;
+import com.liferay.info.item.provider.InfoItemFormProvider;
+import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import javax.portlet.ResourceRequest;
+import javax.portlet.ResourceResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Eudaldo Alonso
+ */
+@Component(
+	property = {
+		"javax.portlet.name=" + ContentPageEditorPortletKeys.CONTENT_PAGE_EDITOR_PORTLET,
+		"mvc.command.name=/layout_content_page_editor/get_info_item_one_to_many_relationship"
+	},
+	service = MVCResourceCommand.class
+)
+public class GetInfoItemOneToManyRelationshipMVCResourceCommand
+	extends BaseMVCResourceCommand {
+
+	@Override
+	protected void doServeResource(
+			ResourceRequest resourceRequest, ResourceResponse resourceResponse)
+		throws Exception {
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)resourceRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		long classNameId = ParamUtil.getLong(resourceRequest, "classNameId");
+
+		InfoItemFormProvider<?> infoItemFormProvider =
+			_infoItemServiceRegistry.getFirstInfoItemService(
+				InfoItemFormProvider.class, _portal.getClassName(classNameId));
+
+		InfoForm infoForm = infoItemFormProvider.getInfoForm();
+
+		JSONArray jsonArray = _jsonFactory.createJSONArray();
+
+		for (InfoItemRelationship infoItemRelationship :
+				infoForm.getInfoFieldRelationships()) {
+
+			jsonArray.put(
+				JSONUtil.put(
+					"classNameId", infoItemRelationship.getClassName()
+				).put(
+					"label",
+					infoItemRelationship.getLabel(themeDisplay.getLocale())
+				));
+		}
+
+		JSONPortletResponseUtil.writeJSON(
+			resourceRequest, resourceResponse, jsonArray);
+	}
+
+	@Reference
+	private InfoItemServiceRegistry _infoItemServiceRegistry;
+
+	@Reference
+	private JSONFactory _jsonFactory;
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/services/InfoItemService.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/services/InfoItemService.ts
@@ -167,10 +167,12 @@ function getStructureRelationships({
 		body.classTypeId = classTypeId;
 	}
 
-	return Promise.resolve([
-		{classNameId: 'relationship-1', label: 'Relationship 1'},
-		{classNameId: 'relationship-2', label: 'Relationship 2'},
-	]);
+	return serviceFetch(config.getInfoItemOneToManyRelationshipsURL, {
+		body: {
+			classNameId,
+			classTypeId,
+		},
+	});
 }
 
 export default {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/services/InfoItemService.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/services/InfoItemService.ts
@@ -149,7 +149,7 @@ function getPageContents({
 	});
 }
 
-function getStructureRelationships({
+function getInfoItemRelationships({
 	classNameId,
 	classTypeId,
 }: {
@@ -182,6 +182,6 @@ export default {
 	getAvailableTemplates,
 	getInfoItemActionErrorMessage,
 	getInfoItemFieldValue,
+	getInfoItemRelationships,
 	getPageContents,
-	getStructureRelationships,
 };

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/MappingSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/MappingSelector.js
@@ -308,7 +308,7 @@ function MappingSelector({
 
 	const relationships = useCache({
 		fetcher: () =>
-			InfoItemService.getStructureRelationships({
+			InfoItemService.getInfoItemRelationships({
 				classNameId: selectedMappingTypes?.type?.id,
 				classTypeId: selectedMappingTypes?.subtype?.id,
 			}),

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/FormInputGeneralPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/FormInputGeneralPanel.js
@@ -402,7 +402,7 @@ function FormInputMappingOptions({
 
 	const relationships = useCache({
 		fetcher: () =>
-			InfoItemService.getStructureRelationships({
+			InfoItemService.getInfoItemRelationships({
 				classNameId,
 				classTypeId,
 			}),

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/FormMappingOptions.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/FormMappingOptions.js
@@ -41,10 +41,11 @@ export default function FormMappingOptions({
 				setClassTypeId(item.config.classTypeId);
 			};
 
-			const saveMapping = () =>
+			const saveMapping = (fields = []) =>
 				onValueSelect({
 					classNameId,
 					classTypeId,
+					fields: fields.map(({uniqueId}) => uniqueId),
 					formConfig: FORM_MAPPING_SOURCES.otherContentType,
 				});
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/types/config.d.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/types/config.d.ts
@@ -135,6 +135,7 @@ export interface Config {
 	getIframeContentURL: string;
 	getInfoItemActionErrorMessageURL: string;
 	getInfoItemFieldValueURL: string;
+	getInfoItemOneToManyRelationshipsURL: string;
 	getLayoutFriendlyURL: string;
 	getLayoutPageTemplateCollectionsURL: string;
 	getPageContentsURL: string;

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/comments/components/MappingSelector.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/comments/components/MappingSelector.test.js
@@ -115,7 +115,7 @@ jest.mock(
 				},
 			])
 		),
-		getStructureRelationships: jest.fn(() =>
+		getInfoItemRelationships: jest.fn(() =>
 			Promise.resolve([
 				{classNameId: 'relationship-1', label: 'Relationship 1'},
 				{classNameId: 'relationship-2', label: 'Relationship 2'},

--- a/modules/apps/layout/layout-content-page-editor-web/types/src/main/resources/META-INF/resources/page_editor/app/services/InfoItemService.d.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/types/src/main/resources/META-INF/resources/page_editor/app/services/InfoItemService.d.ts
@@ -63,18 +63,13 @@ declare function getPageContents({
 }: {
 	segmentsExperienceId: State['segmentsExperienceId'];
 }): Promise<PageContent[]>;
-declare function getStructureRelationships({
+declare function getInfoItemRelationships({
 	classNameId,
 	classTypeId,
 }: {
 	classNameId: string;
 	classTypeId?: string;
-}): Promise<
-	{
-		classNameId: string;
-		label: string;
-	}[]
->;
+}): Promise<unknown>;
 declare const _default: {
 	getAvailableListItemRenderers: typeof getAvailableListItemRenderers;
 	getAvailableListRenderers: typeof getAvailableListRenderers;
@@ -82,7 +77,7 @@ declare const _default: {
 	getAvailableTemplates: typeof getAvailableTemplates;
 	getInfoItemActionErrorMessage: typeof getInfoItemActionErrorMessage;
 	getInfoItemFieldValue: typeof getInfoItemFieldValue;
+	getInfoItemRelationships: typeof getInfoItemRelationships;
 	getPageContents: typeof getPageContents;
-	getStructureRelationships: typeof getStructureRelationships;
 };
 export default _default;

--- a/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/provider/util/ObjectEntryInfoItemFormProviderUtil.java
+++ b/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/provider/util/ObjectEntryInfoItemFormProviderUtil.java
@@ -7,6 +7,7 @@ package com.liferay.object.info.item.provider.util;
 
 import com.liferay.info.exception.NoSuchFormVariationException;
 import com.liferay.info.field.InfoField;
+import com.liferay.info.item.InfoItemRelationship;
 import com.liferay.info.field.InfoFieldSet;
 import com.liferay.info.field.type.ActionInfoFieldType;
 import com.liferay.info.field.type.ImageInfoFieldType;
@@ -29,6 +30,7 @@ import com.liferay.object.service.ObjectActionLocalService;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
@@ -301,6 +303,37 @@ public class ObjectEntryInfoItemFormProviderUtil {
 			).build()
 		).name(
 			modelClassName
+		).relationships(
+			TransformUtil.transform(
+				objectRelationshipLocalService.getObjectRelationships(
+					objectDefinitionId,
+					ObjectRelationshipConstants.TYPE_ONE_TO_MANY),
+				objectRelationship -> {
+					if (!objectRelationship.isSelf() &&
+							Objects.equals(
+								objectDefinitionId,
+								objectRelationship.getObjectDefinitionId1())) {
+
+						return null;
+					}
+
+					ObjectDefinition parentObjectDefinition =
+						objectDefinitionLocalService.fetchObjectDefinition(
+							objectRelationship.getObjectDefinitionId1());
+
+					return InfoItemRelationship.builder(
+					).className(
+						parentObjectDefinition.getClassName()
+					).labelInfoLocalizedValue(
+						InfoLocalizedValue.<String>builder(
+						).defaultLocale(
+							LocaleUtil.fromLanguageId(
+								parentObjectDefinition.getDefaultLanguageId())
+						).values(
+							parentObjectDefinition.getLabelMap()
+						).build()
+					).build();
+				})
 		).build();
 	}
 

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFormProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFormProvider.java
@@ -77,7 +77,7 @@ public class ObjectEntryInfoItemFormProvider
 	public InfoForm getInfoForm() {
 		try {
 			return _getInfoForm(
-				0,
+				_objectDefinition.getObjectDefinitionId(),
 				_displayPageInfoItemFieldSetProvider.getInfoFieldSet(
 					_getModelClassName(0), StringPool.BLANK,
 					ObjectEntry.class.getSimpleName(), 0));


### PR DESCRIPTION
- LPD-23768 Add to display context
- LPD-23768 Call real URL
- LPD-23768 Rename
- LPD-23768 Adapt tests
- LPD-23768 Types
- LPD-25328 Send fields uniqueId
- LPD-25327 Adds new interface to represent Relationships between info items
- LPD-25327 Adds Relationships to InfoForm
- LPD-25327 Adds new resource command to get one to many relationships
- LPD-25327 Includes InfoItemRelationship to item selector
- LPD-25327 Adds supports for ResultRowSplitter on item selector views
- LPD-25327 Implements for objects
- LPD-25327 baseline
- LPD-25327 Uses ObjectDefinitionId instead of 0
