### PR TITLE
LPD-26921 Add test This is a test for LPS-102566, LPS-109594, LPS-119…

### DIFF
--- a/modules/test/playwright/tests/layout-page-template-admin-web/fixtures/masterPagesTest.ts
+++ b/modules/test/playwright/tests/layout-page-template-admin-web/fixtures/masterPagesTest.ts
@@ -7,13 +7,18 @@
 
 import {test} from '@playwright/test';
 
+import {PageEditorPage} from '../../../pages/layout-content-page-editor-web/PageEditorPage';
 import {MasterPagesPage} from '../pages/MasterPagesPage';
 
 const masterPagesTest = test.extend<{
 	masterPagesPage: MasterPagesPage;
+	pageEditorPage: PageEditorPage;
 }>({
 	masterPagesPage: async ({page}, use) => {
 		await use(new MasterPagesPage(page));
+	},
+	pageEditorPage: async ({page}, use) => {
+		await use(new PageEditorPage(page));
 	},
 });
 

--- a/modules/test/playwright/tests/layout-page-template-admin-web/masterPagesAdmin.spec.ts
+++ b/modules/test/playwright/tests/layout-page-template-admin-web/masterPagesAdmin.spec.ts
@@ -27,3 +27,46 @@ test('This is for LPS-102202. Validate if the Blank page template can not be edi
 		templateCard.locator('.custom-control.custom-checkbox')
 	).not.toBeVisible();
 });
+
+test('This is a test for LPS-102566, LPS-109594, LPS-119634 and LPS-104629. Add a page based on custom master.', async ({
+	masterPagesPage,
+	page,
+	pageEditorPage,
+	site,
+}) => {
+	const nameNewMasterPage = 'New Master Page';
+
+	await test.step('Create and publish new custom master page', async () => {
+		await masterPagesPage.goto(site.friendlyUrlPath);
+
+		masterPagesPage.publishNewMasterTemplate(nameNewMasterPage);
+
+		const templateCard = masterPagesPage.getTemplateCard(nameNewMasterPage);
+
+		await expect(templateCard).toBeVisible();
+
+		await expect(templateCard.getByLabel('More actions')).toBeVisible();
+
+		await expect(
+			templateCard.locator('.custom-control.custom-checkbox')
+		).toBeVisible();
+	});
+
+	await test.step('Assert header of Drop Zone is inside body by default', async () => {
+		masterPagesPage.clickAndEdit(nameNewMasterPage);
+
+		await expect(page.locator('.page-editor__drop-zone')).toBeVisible();
+
+		await expect(
+			page.getByText(
+				'Fragments and widgets for pages based on this master will be placed here.'
+			)
+		).toBeVisible();
+		await expect(
+			page.getByText('Configure Allowed Fragments')
+		).toBeVisible();
+	});
+	await test.step('Add and configure a Button fragment on master page', async () => {
+		await pageEditorPage.addFragment('Basic Components', 'Button');
+	});
+});

--- a/modules/test/playwright/tests/layout-page-template-admin-web/pages/MasterPagesPage.ts
+++ b/modules/test/playwright/tests/layout-page-template-admin-web/pages/MasterPagesPage.ts
@@ -3,15 +3,20 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {Page} from '@playwright/test';
+import {Locator, Page} from '@playwright/test';
 
 import {PORTLET_URLS} from '../../../utils/portletUrls';
 
 export class MasterPagesPage {
 	readonly page: Page;
 
+	readonly newButton: Locator;
+	readonly publishButton: Locator;
+
 	constructor(page: Page) {
 		this.page = page;
+		this.newButton = page.getByText('New', {exact: true});
+		this.publishButton = page.getByLabel('Publish Master', {exact: true});
 	}
 
 	async goto(siteUrl?: Site['friendlyUrlPath']) {
@@ -22,5 +27,21 @@ export class MasterPagesPage {
 
 	getTemplateCard(name: string) {
 		return this.page.locator('.card-page-item').filter({hasText: name});
+	}
+
+	async publishNewMasterTemplate(name: string) {
+		await this.newButton.click();
+		await this.page.getByLabel('Name').fill(name);
+		await this.page.getByRole('button', {name: 'Save'}).click();
+		await this.publishButton.waitFor();
+		await this.publishButton.click();
+	}
+
+	async clickMoreActions(name: string) {
+		await this.getTemplateCard(name).getByLabel('More actions').click();
+	}
+
+	async clickAndEdit(name: string) {
+		await this.getTemplateCard(name).getByLabel(name).click();
 	}
 }


### PR DESCRIPTION
…634 and LPS-104629. Add a page based on custom master.

@sandrodw3 please check why I get a failing error when using `pageEditorPage.addFragment('Basic Components', 'Button');`

`[layout-page-template-admin-web] › layout-page-template-admin-web/masterPagesAdmin.spec.ts:31:1 › This is a test for LPS-102566, LPS-109594, LPS-119634 and LPS-104629. Add a page based on custom master. › Add and configure a Button fragment on master page 

    Test timeout of 90000ms exceeded.

    Error: locator.waitFor: Page closed
    =========================== logs ===========================
    waiting for getByLabel('Saved') to be visible
    ============================================================

       at ../pages/layout-content-page-editor-web/PageEditorPage.ts:564

      562 |
      563 |     async waitForChangesSaved() {
    > 564 |             await this.page.getByLabel('Saved').waitFor();
          |                                                 ^
      565 |
      566 |             await this.page
      567 |                     .getByText(

        at PageEditorPage.waitForChangesSaved (/home/georgelpop/liferay/repos/liferay-portal/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts:564:39)
        at PageEditorPage.addFragment (/home/georgelpop/liferay/repos/liferay-portal/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts:67:14)
        at /home/georgelpop/liferay/repos/liferay-portal/modules/test/playwright/tests/layout-page-template-admin-web/masterPagesAdmin.spec.ts:68:3
        at /home/georgelpop/liferay/repos/liferay-portal/modules/test/playwright/tests/layout-page-template-admin-web/masterPagesAdmin.spec.ts:67:2

    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
    test-results/masterPagesAdmin-This-is-a-test-for-LPS-102566-4ea3c-d-LPS-104629-Add-a-page-based-on-custom-master--layout-page-template-admin-web/test-failed-1.png
    ────────────────────────────────────────────────────────────────────────────────────────────────

    attachment #2: screenshot (image/png) ──────────────────────────────────────────────────────────
    test-results/masterPagesAdmin-This-is-a-test-for-LPS-102566-4ea3c-d-LPS-104629-Add-a-page-based-on-custom-master--layout-page-template-admin-web/test-failed-2.png
    ────────────────────────────────────────────────────────────────────────────────────────────────

    attachment #3: trace (application/zip) ─────────────────────────────────────────────────────────
    test-results/masterPagesAdmin-This-is-a-test-for-LPS-102566-4ea3c-d-LPS-104629-Add-a-page-based-on-custom-master--layout-page-template-admin-web/trace.zip
    Usage:

        npx playwright show-trace test-results/masterPagesAdmin-This-is-a-test-for-LPS-102566-4ea3c-d-LPS-104629-Add-a-page-based-on-custom-master--layout-page-template-admin-web/trace.zip

    ────────────────────────────────────────────────────────────────────────────────────────────────

  Slow test file: [layout-page-template-admin-web] › layout-page-template-admin-web/masterPagesAdmin.spec.ts (1.8m)
  Consider splitting slow test files to speed up parallel execution
  1 failed
    [layout-page-template-admin-web] › layout-page-template-admin-web/masterPagesAdmin.spec.ts:31:1 › This is a test for LPS-102566, LPS-109594, LPS-119634 and LPS-104629. Add a page based on custom master.`
