### PR TITLE
LPD 26916 1

### DIFF
--- a/modules/apps/info/info-api/bnd.bnd
+++ b/modules/apps/info/info-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Info API
 Bundle-SymbolicName: com.liferay.info.api
-Bundle-Version: 36.4.1
+Bundle-Version: 36.5.0
 Export-Package:\
 	com.liferay.info.collection.provider,\
 	com.liferay.info.constants,\

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/item/provider/RelatedInfoItemProvider.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/item/provider/RelatedInfoItemProvider.java
@@ -1,0 +1,30 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.info.item.provider;
+
+import com.liferay.info.type.Keyed;
+import com.liferay.petra.reflect.GenericUtil;
+
+import java.util.List;
+
+/**
+ * @author Eudaldo Alonso
+ */
+public interface RelatedInfoItemProvider<T> extends Keyed {
+
+	public List<String> getRelatedItemClassNames();
+
+	public default Class<?> getSourceItemClass() {
+		return GenericUtil.getGenericClass(this);
+	}
+
+	public default String getSourceItemClassName() {
+		Class<?> clazz = getSourceItemClass();
+
+		return clazz.getName();
+	}
+
+}

--- a/modules/apps/info/info-api/src/main/resources/com/liferay/info/item/provider/packageinfo
+++ b/modules/apps/info/info-api/src/main/resources/com/liferay/info/item/provider/packageinfo
@@ -1,1 +1,1 @@
-version 4.2.0
+version 4.3.0

--- a/modules/apps/info/info-field-item-selector-web/build.gradle
+++ b/modules/apps/info/info-field-item-selector-web/build.gradle
@@ -5,10 +5,13 @@ dependencies {
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:fragment:fragment-api")
 	compileOnly project(":apps:info:info-api")
 	compileOnly project(":apps:info:info-field-item-selector-api")
 	compileOnly project(":apps:item-selector:item-selector-api")
 	compileOnly project(":apps:item-selector:item-selector-criteria-api")
+	compileOnly project(":apps:layout:layout-api")
+	compileOnly project(":apps:layout:layout-page-template-api")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/info/info-field-item-selector-web/src/main/java/com/liferay/info/field/item/selector/web/internal/InfoFieldItemSelectorViewDescriptor.java
+++ b/modules/apps/info/info-field-item-selector-web/src/main/java/com/liferay/info/field/item/selector/web/internal/InfoFieldItemSelectorViewDescriptor.java
@@ -5,10 +5,15 @@
 
 package com.liferay.info.field.item.selector.web.internal;
 
+import com.liferay.fragment.model.FragmentEntryLink;
+import com.liferay.fragment.service.FragmentEntryLinkLocalServiceUtil;
+import com.liferay.fragment.util.configuration.FragmentConfigurationField;
+import com.liferay.fragment.util.configuration.FragmentEntryConfigurationParser;
 import com.liferay.info.exception.NoSuchFormVariationException;
 import com.liferay.info.field.InfoField;
 import com.liferay.info.field.InfoFieldSet;
 import com.liferay.info.field.InfoFieldSetEntry;
+import com.liferay.info.field.item.selector.web.internal.search.InfoFieldItemSelectorChecker;
 import com.liferay.info.form.InfoForm;
 import com.liferay.info.item.InfoItemServiceRegistry;
 import com.liferay.info.item.provider.InfoItemFormProvider;
@@ -17,6 +22,12 @@ import com.liferay.item.selector.ItemSelectorReturnType;
 import com.liferay.item.selector.ItemSelectorViewDescriptor;
 import com.liferay.item.selector.TableItemView;
 import com.liferay.item.selector.criteria.UUIDItemSelectorReturnType;
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalServiceUtil;
+import com.liferay.layout.util.structure.FormStyledLayoutStructureItem;
+import com.liferay.layout.util.structure.FragmentStyledLayoutStructureItem;
+import com.liferay.layout.util.structure.LayoutStructure;
+import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.search.ResultRow;
@@ -27,6 +38,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -42,6 +54,7 @@ import java.util.Map;
 
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletURL;
+import javax.portlet.RenderResponse;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -53,14 +66,20 @@ public class InfoFieldItemSelectorViewDescriptor
 
 	public InfoFieldItemSelectorViewDescriptor(
 		HttpServletRequest httpServletRequest,
-		InfoItemServiceRegistry infoItemServiceRegistry,
-		PortletURL portletURL) {
+		FragmentEntryConfigurationParser fragmentEntryConfigurationParser,
+		InfoItemServiceRegistry infoItemServiceRegistry, PortletURL portletURL,
+		RenderResponse renderResponse) {
 
 		_httpServletRequest = httpServletRequest;
+		_fragmentEntryConfigurationParser = fragmentEntryConfigurationParser;
 		_infoItemServiceRegistry = infoItemServiceRegistry;
 		_portletURL = portletURL;
+		_renderResponse = renderResponse;
 
+		_formItemId = ParamUtil.getString(httpServletRequest, "formItemId");
 		_itemType = ParamUtil.getString(httpServletRequest, "itemType");
+		_segmentsExperienceId = ParamUtil.getLong(
+			httpServletRequest, "segmentsExperienceId");
 		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 	}
@@ -138,6 +157,10 @@ public class InfoFieldItemSelectorViewDescriptor
 			return searchContainer;
 		}
 
+		searchContainer.setRowChecker(
+			new InfoFieldItemSelectorChecker(
+				_renderResponse, _getCheckedInfoFieldUniqueIds()));
+
 		InfoForm infoForm = infoItemFormProvider.getInfoForm(
 			_itemType, _themeDisplay.getScopeGroupId());
 
@@ -180,6 +203,62 @@ public class InfoFieldItemSelectorViewDescriptor
 	@Override
 	public boolean isShowSearch() {
 		return true;
+	}
+
+	private List<String> _getCheckedInfoFieldUniqueIds() {
+		LayoutPageTemplateStructure layoutPageTemplateStructure =
+			LayoutPageTemplateStructureLocalServiceUtil.
+				fetchLayoutPageTemplateStructure(
+					_themeDisplay.getScopeGroupId(), _themeDisplay.getPlid());
+
+		if (layoutPageTemplateStructure == null) {
+			return Collections.emptyList();
+		}
+
+		LayoutStructure layoutStructure = LayoutStructure.of(
+			layoutPageTemplateStructure.getData(_segmentsExperienceId));
+
+		LayoutStructureItem layoutStructureItem =
+			layoutStructure.getLayoutStructureItem(_formItemId);
+
+		if (!(layoutStructureItem instanceof FormStyledLayoutStructureItem)) {
+			return Collections.emptyList();
+		}
+
+		List<String> checkedInfoFieldUniqueIds = new ArrayList<>();
+
+		FormStyledLayoutStructureItem formStyledLayoutStructureItem =
+			(FormStyledLayoutStructureItem)layoutStructureItem;
+
+		for (String itemId :
+				formStyledLayoutStructureItem.getChildrenItemIds()) {
+
+			FragmentStyledLayoutStructureItem
+				fragmentStyledLayoutStructureItem =
+					(FragmentStyledLayoutStructureItem)
+						layoutStructure.getLayoutStructureItem(itemId);
+
+			FragmentEntryLink fragmentEntryLink =
+				FragmentEntryLinkLocalServiceUtil.fetchFragmentEntryLink(
+					fragmentStyledLayoutStructureItem.getFragmentEntryLinkId());
+
+			if (fragmentEntryLink == null) {
+				continue;
+			}
+
+			String inputFieldId = GetterUtil.getString(
+				_fragmentEntryConfigurationParser.getFieldValue(
+					fragmentEntryLink.getEditableValues(),
+					new FragmentConfigurationField(
+						"inputFieldId", "string", "", false, "text"),
+					_themeDisplay.getLocale()));
+
+			if (Validator.isNotNull(inputFieldId)) {
+				checkedInfoFieldUniqueIds.add(inputFieldId);
+			}
+		}
+
+		return checkedInfoFieldUniqueIds;
 	}
 
 	private Map<InfoField<?>, InfoFieldSet> _getInfoFieldMap() {
@@ -242,10 +321,15 @@ public class InfoFieldItemSelectorViewDescriptor
 	private static final Log _log = LogFactoryUtil.getLog(
 		InfoFieldItemSelectorViewDescriptor.class);
 
+	private final String _formItemId;
+	private final FragmentEntryConfigurationParser
+		_fragmentEntryConfigurationParser;
 	private final HttpServletRequest _httpServletRequest;
 	private final InfoItemServiceRegistry _infoItemServiceRegistry;
 	private final String _itemType;
 	private final PortletURL _portletURL;
+	private final RenderResponse _renderResponse;
+	private final long _segmentsExperienceId;
 	private final ThemeDisplay _themeDisplay;
 
 }

--- a/modules/apps/info/info-field-item-selector-web/src/main/java/com/liferay/info/field/item/selector/web/internal/InfoFieldProviderItemSelectorView.java
+++ b/modules/apps/info/info-field-item-selector-web/src/main/java/com/liferay/info/field/item/selector/web/internal/InfoFieldProviderItemSelectorView.java
@@ -5,6 +5,7 @@
 
 package com.liferay.info.field.item.selector.web.internal;
 
+import com.liferay.fragment.util.configuration.FragmentEntryConfigurationParser;
 import com.liferay.info.field.item.selector.criterion.InfoFieldItemSelectorCriterion;
 import com.liferay.info.item.InfoItemServiceRegistry;
 import com.liferay.item.selector.ItemSelectorReturnType;
@@ -12,6 +13,7 @@ import com.liferay.item.selector.ItemSelectorView;
 import com.liferay.item.selector.ItemSelectorViewDescriptorRenderer;
 import com.liferay.item.selector.criteria.UUIDItemSelectorReturnType;
 import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.util.JavaConstants;
 
 import java.io.IOException;
 
@@ -20,6 +22,7 @@ import java.util.List;
 import java.util.Locale;
 
 import javax.portlet.PortletURL;
+import javax.portlet.RenderResponse;
 
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
@@ -66,16 +69,24 @@ public class InfoFieldProviderItemSelectorView
 		HttpServletRequest httpServletRequest =
 			(HttpServletRequest)servletRequest;
 
+		RenderResponse renderResponse =
+			(RenderResponse)httpServletRequest.getAttribute(
+				JavaConstants.JAVAX_PORTLET_RESPONSE);
+
 		_itemSelectorViewDescriptorRenderer.renderHTML(
 			servletRequest, servletResponse, infoFieldItemSelectorCriterion,
 			portletURL, itemSelectedEventName, search,
 			new InfoFieldItemSelectorViewDescriptor(
-				httpServletRequest, _infoItemServiceRegistry, portletURL));
+				httpServletRequest, _fragmentEntryConfigurationParser,
+				_infoItemServiceRegistry, portletURL, renderResponse));
 	}
 
 	private static final List<ItemSelectorReturnType>
 		_supportedItemSelectorReturnTypes = Collections.singletonList(
 			new UUIDItemSelectorReturnType());
+
+	@Reference
+	private FragmentEntryConfigurationParser _fragmentEntryConfigurationParser;
 
 	@Reference
 	private InfoItemServiceRegistry _infoItemServiceRegistry;

--- a/modules/apps/info/info-field-item-selector-web/src/main/java/com/liferay/info/field/item/selector/web/internal/search/InfoFieldItemSelectorChecker.java
+++ b/modules/apps/info/info-field-item-selector-web/src/main/java/com/liferay/info/field/item/selector/web/internal/search/InfoFieldItemSelectorChecker.java
@@ -1,0 +1,42 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.info.field.item.selector.web.internal.search;
+
+import com.liferay.info.field.InfoField;
+import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
+
+import java.util.List;
+
+import javax.portlet.RenderResponse;
+
+/**
+ * @author Eudaldo Alonso
+ */
+public class InfoFieldItemSelectorChecker extends EmptyOnClickRowChecker {
+
+	public InfoFieldItemSelectorChecker(
+		RenderResponse renderResponse, List<String> checkedInfoFieldUniqueIds) {
+
+		super(renderResponse);
+
+		_checkedInfoFieldUniqueIds = checkedInfoFieldUniqueIds;
+	}
+
+	@Override
+	public boolean isChecked(Object object) {
+		InfoField<?> infoField = (InfoField<?>)object;
+
+		return _checkedInfoFieldUniqueIds.contains(infoField.getUniqueId());
+	}
+
+	@Override
+	public boolean isDisabled(Object object) {
+		return isChecked(object);
+	}
+
+	private final List<String> _checkedInfoFieldUniqueIds;
+
+}

--- a/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/item/InfoItemServiceRegistryImpl.java
+++ b/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/item/InfoItemServiceRegistryImpl.java
@@ -32,6 +32,7 @@ import com.liferay.info.item.provider.InfoItemObjectVariationProvider;
 import com.liferay.info.item.provider.InfoItemPermissionProvider;
 import com.liferay.info.item.provider.InfoItemScopeProvider;
 import com.liferay.info.item.provider.InfoItemStatusProvider;
+import com.liferay.info.item.provider.RelatedInfoItemProvider;
 import com.liferay.info.item.provider.filter.InfoItemServiceFilter;
 import com.liferay.info.item.provider.filter.OptionalPropertyInfoItemServiceFilter;
 import com.liferay.info.item.renderer.InfoItemRenderer;
@@ -409,7 +410,8 @@ public class InfoItemServiceRegistryImpl implements InfoItemServiceRegistry {
 			InfoItemScopeProvider.class, InfoItemStatusProvider.class,
 			InfoListRenderer.class, InfoPermissionProvider.class,
 			InfoRequestItemProvider.class, InfoTextFormatter.class,
-			RelatedInfoItemCollectionProvider.class));
+			RelatedInfoItemCollectionProvider.class,
+			RelatedInfoItemProvider.class));
 
 	private BundleContext _bundleContext;
 	private final Map

--- a/modules/apps/layout/layout-content-page-editor-web-test/build.gradle
+++ b/modules/apps/layout/layout-content-page-editor-web-test/build.gradle
@@ -31,6 +31,8 @@ dependencies {
 	testIntegrationImplementation project(":apps:layout:layout-taglib")
 	testIntegrationImplementation project(":apps:layout:layout-test-util")
 	testIntegrationImplementation project(":apps:mentions:mentions-api")
+	testIntegrationImplementation project(":apps:object:object-api")
+	testIntegrationImplementation project(":apps:object:object-test-util")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-api")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-test-util")

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/GetInfoItemOneToManyRelationshipsMVCResourceCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/GetInfoItemOneToManyRelationshipsMVCResourceCommandTest.java
@@ -1,0 +1,158 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.content.page.editor.web.internal.portlet.action.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.field.util.ObjectFieldUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.object.test.util.ObjectRelationshipTestUtil;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.test.portlet.MockLiferayResourceRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayResourceResponse;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.io.ByteArrayOutputStream;
+
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Eudaldo Alonso
+ */
+@RunWith(Arquillian.class)
+public class GetInfoItemOneToManyRelationshipsMVCResourceCommandTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition(
+			Collections.singletonList(
+				ObjectFieldUtil.createObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_RICH_TEXT,
+					ObjectFieldConstants.DB_TYPE_STRING, "myRichText",
+					"myRichText", false)));
+	}
+
+	@Test
+	public void testGetInfoItemOneToManyRelationships() throws Exception {
+		_objectDefinition2 = ObjectDefinitionTestUtil.publishObjectDefinition(
+			Collections.singletonList(
+				ObjectFieldUtil.createObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+					ObjectFieldConstants.DB_TYPE_STRING, "myText", "myText",
+					false)));
+
+		ObjectRelationshipTestUtil.addObjectRelationship(
+			_objectRelationshipLocalService, _objectDefinition2,
+			_objectDefinition1);
+
+		MockLiferayResourceRequest mockLiferayResourceRequest =
+			new MockLiferayResourceRequest();
+
+		mockLiferayResourceRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _getThemeDisplay());
+		mockLiferayResourceRequest.setParameter(
+			"classNameId",
+			String.valueOf(
+				_portal.getClassNameId(_objectDefinition1.getClassName())));
+
+		MockLiferayResourceResponse mockLiferayResourceResponse =
+			new MockLiferayResourceResponse();
+
+		_mvcResourceCommand.serveResource(
+			mockLiferayResourceRequest, mockLiferayResourceResponse);
+
+		JSONArray jsonArray = _getJSONArray(mockLiferayResourceResponse);
+
+		Assert.assertEquals(1, jsonArray.length());
+
+		JSONObject jsonObject = jsonArray.getJSONObject(0);
+
+		Assert.assertEquals(
+			_portal.getClassNameId(_objectDefinition2.getClassName()),
+			jsonObject.getLong("classNameId"));
+		Assert.assertEquals(
+			_objectDefinition2.getLabel(LocaleUtil.getDefault()),
+			jsonObject.getString("label"));
+	}
+
+	@Test
+	public void testWithEmptyClassNameId() throws Exception {
+		MockLiferayResourceResponse mockLiferayResourceResponse =
+			new MockLiferayResourceResponse();
+
+		_mvcResourceCommand.serveResource(
+			new MockLiferayResourceRequest(), mockLiferayResourceResponse);
+
+		JSONArray jsonArray = _getJSONArray(mockLiferayResourceResponse);
+
+		Assert.assertEquals(0, jsonArray.length());
+	}
+
+	private JSONArray _getJSONArray(
+			MockLiferayResourceResponse mockLiferayResourceResponse)
+		throws Exception {
+
+		ByteArrayOutputStream byteArrayOutputStream =
+			(ByteArrayOutputStream)
+				mockLiferayResourceResponse.getPortletOutputStream();
+
+		return JSONFactoryUtil.createJSONArray(
+			byteArrayOutputStream.toString());
+	}
+
+	private ThemeDisplay _getThemeDisplay() {
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setLocale(LocaleUtil.getDefault());
+
+		return themeDisplay;
+	}
+
+	@Inject(
+		filter = "mvc.command.name=/layout_content_page_editor/get_info_item_one_to_many_relationships"
+	)
+	private MVCResourceCommand _mvcResourceCommand;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition1;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition2;
+
+	@Inject
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
+
+	@Inject
+	private Portal _portal;
+
+}

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/UpdateFormItemConfigMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/UpdateFormItemConfigMVCActionCommandTest.java
@@ -37,6 +37,7 @@ import com.liferay.layout.util.constants.LayoutDataItemTypeConstants;
 import com.liferay.layout.util.structure.FormStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.FragmentStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructure;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONArray;
@@ -67,6 +68,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.FeatureFlags;
@@ -77,6 +79,7 @@ import com.liferay.segments.service.SegmentsExperienceLocalService;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.TreeSet;
 
 import javax.portlet.ActionRequest;
@@ -351,6 +354,84 @@ public class UpdateFormItemConfigMVCActionCommandTest {
 
 			_assertFormStyledLayoutStructureItem(
 				classNameId, 0, formItemId, new InfoField<?>[0], true, false);
+		}
+	}
+
+	@FeatureFlags("LPD-20213")
+	@Test
+	public void testUpdateFormItemConfigMVCActionCommandMappingFormWithNewFields()
+		throws Exception {
+
+		InfoField<?>[] allInfoFields = ArrayUtil.append(
+			_INFO_FIELDS,
+			new InfoField<?>[] {
+				_getInfoField(
+					BooleanInfoFieldType.INSTANCE,
+					RandomTestUtil.randomString()),
+				_getInfoField(
+					TextInfoFieldType.INSTANCE, RandomTestUtil.randomString())
+			});
+
+		try (ComponentEnablerTemporarySwapper componentEnablerTemporarySwapper =
+				new ComponentEnablerTemporarySwapper(
+					_BUNDLE_SYMBOLIC_NAME, _COMPONENT_CLASS_NAME, true);
+			MockInfoServiceRegistrationHolder
+				mockInfoServiceRegistrationHolder =
+					new MockInfoServiceRegistrationHolder(
+						InfoFieldSet.builder(
+						).infoFieldSetEntries(
+							ListUtil.fromArray(allInfoFields)
+						).build(),
+						_portal, _editPageInfoItemCapability)) {
+
+			JSONObject addItemJSONObject =
+				ContentLayoutTestUtil.addItemToLayout(
+					"{}", LayoutDataItemTypeConstants.TYPE_FORM, _layout,
+					_layoutStructureProvider, _segmentsExperienceId);
+
+			long classNameId = _portal.getClassNameId(
+				MockObject.class.getName());
+
+			String formItemId = addItemJSONObject.getString("addedItemId");
+
+			List<String> fields = TransformUtil.transform(
+				ListUtil.fromArray(_INFO_FIELDS), InfoField::getUniqueId);
+
+			ReflectionTestUtil.invoke(
+				_mvcActionCommand, "_updateFormStyledLayoutStructureItemConfig",
+				new Class<?>[] {ActionRequest.class, ActionResponse.class},
+				_getMockLiferayPortletActionRequest(
+					StringUtil.merge(fields),
+					JSONUtil.put(
+						"classNameId", classNameId
+					).put(
+						"classTypeId", "0"
+					).toString(),
+					formItemId, _layout),
+				new MockLiferayPortletActionResponse());
+
+			fields = TransformUtil.transform(
+				ListUtil.fromArray(allInfoFields), InfoField::getUniqueId);
+
+			JSONObject updateFormJSONObject = ReflectionTestUtil.invoke(
+				_mvcActionCommand, "_updateFormStyledLayoutStructureItemConfig",
+				new Class<?>[] {ActionRequest.class, ActionResponse.class},
+				_getMockLiferayPortletActionRequest(
+					StringUtil.merge(fields),
+					JSONUtil.put(
+						"classNameId", classNameId
+					).put(
+						"classTypeId", "0"
+					).toString(),
+					formItemId, _layout),
+				new MockLiferayPortletActionResponse());
+
+			_assertUpdateFormStyledLayoutStructureItemConfigJSONObject(
+				updateFormJSONObject, 2, StringPool.BLANK, StringPool.BLANK, 0);
+
+			_assertFormStyledLayoutStructureItem(
+				classNameId, allInfoFields.length + 1, formItemId,
+				allInfoFields, true, false);
 		}
 	}
 
@@ -712,19 +793,33 @@ public class UpdateFormItemConfigMVCActionCommandTest {
 			childrenItemIds.toString(), expectedChildrenSize,
 			childrenItemIds.size());
 
-		for (int i = 0; i < infoFields.length; i++) {
-			InfoField<?> infoField = infoFields[i];
+		int i = 0;
 
+		for (String itemId : childrenItemIds) {
 			FragmentStyledLayoutStructureItem
 				fragmentStyledLayoutStructureItem =
 					(FragmentStyledLayoutStructureItem)
-						layoutStructure.getLayoutStructureItem(
-							childrenItemIds.get(i));
+						layoutStructure.getLayoutStructureItem(itemId);
 
-			_assertFragmentEntry(
-				infoField.getUniqueId(), _getExpectedRendererKey(infoField),
-				fragmentStyledLayoutStructureItem.getFragmentEntryLinkId(),
-				assertRendererKey);
+			FragmentEntryLink fragmentEntryLink =
+				_fragmentEntryLinkLocalService.getFragmentEntryLink(
+					fragmentStyledLayoutStructureItem.getFragmentEntryLinkId());
+
+			if (Objects.equals(
+					fragmentEntryLink.getRendererKey(),
+					"INPUTS-submit-button")) {
+
+				_assertFragmentEntry(
+					StringPool.BLANK, "INPUTS-submit-button", fragmentEntryLink,
+					assertRendererKey);
+			}
+			else {
+				InfoField<?> infoField = infoFields[i++];
+
+				_assertFragmentEntry(
+					infoField.getUniqueId(), _getExpectedRendererKey(infoField),
+					fragmentEntryLink, assertRendererKey);
+			}
 		}
 
 		if (!submitButton) {
@@ -738,18 +833,14 @@ public class UpdateFormItemConfigMVCActionCommandTest {
 
 		_assertFragmentEntry(
 			StringPool.BLANK, "INPUTS-submit-button",
-			fragmentStyledLayoutStructureItem.getFragmentEntryLinkId(),
+			_fragmentEntryLinkLocalService.getFragmentEntryLink(
+				fragmentStyledLayoutStructureItem.getFragmentEntryLinkId()),
 			assertRendererKey);
 	}
 
 	private void _assertFragmentEntry(
-			String expectedInputFieldId, String expectedRendererKey,
-			long fragmentEntryLinkId, boolean assertRendererKey)
-		throws PortalException {
-
-		FragmentEntryLink fragmentEntryLink =
-			_fragmentEntryLinkLocalService.getFragmentEntryLink(
-				fragmentEntryLinkId);
+		String expectedInputFieldId, String expectedRendererKey,
+		FragmentEntryLink fragmentEntryLink, boolean assertRendererKey) {
 
 		String inputFieldId = GetterUtil.getString(
 			_fragmentEntryConfigurationParser.getFieldValue(

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/UpdateFormItemConfigMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/UpdateFormItemConfigMVCActionCommandTest.java
@@ -311,6 +311,84 @@ public class UpdateFormItemConfigMVCActionCommandTest {
 
 	@FeatureFlags("LPD-20213")
 	@Test
+	public void testUpdateFormItemConfigMVCActionCommandMappingFormDeletingFields()
+		throws Exception {
+
+		InfoField<?>[] allInfoFields = ArrayUtil.append(
+			_INFO_FIELDS,
+			new InfoField<?>[] {
+				_getInfoField(
+					BooleanInfoFieldType.INSTANCE,
+					RandomTestUtil.randomString()),
+				_getInfoField(
+					TextInfoFieldType.INSTANCE, RandomTestUtil.randomString())
+			});
+
+		try (ComponentEnablerTemporarySwapper componentEnablerTemporarySwapper =
+				new ComponentEnablerTemporarySwapper(
+					_BUNDLE_SYMBOLIC_NAME, _COMPONENT_CLASS_NAME, true);
+			MockInfoServiceRegistrationHolder
+				mockInfoServiceRegistrationHolder =
+					new MockInfoServiceRegistrationHolder(
+						InfoFieldSet.builder(
+						).infoFieldSetEntries(
+							ListUtil.fromArray(allInfoFields)
+						).build(),
+						_portal, _editPageInfoItemCapability)) {
+
+			JSONObject addItemJSONObject =
+				ContentLayoutTestUtil.addItemToLayout(
+					"{}", LayoutDataItemTypeConstants.TYPE_FORM, _layout,
+					_layoutStructureProvider, _segmentsExperienceId);
+
+			long classNameId = _portal.getClassNameId(
+				MockObject.class.getName());
+
+			String formItemId = addItemJSONObject.getString("addedItemId");
+
+			List<String> fields = TransformUtil.transform(
+				ListUtil.fromArray(allInfoFields), InfoField::getUniqueId);
+
+			ReflectionTestUtil.invoke(
+				_mvcActionCommand, "doTransactionalCommand",
+				new Class<?>[] {ActionRequest.class, ActionResponse.class},
+				_getMockLiferayPortletActionRequest(
+					StringUtil.merge(fields),
+					JSONUtil.put(
+						"classNameId", classNameId
+					).put(
+						"classTypeId", "0"
+					).toString(),
+					formItemId, _layout),
+				new MockLiferayPortletActionResponse());
+
+			fields = TransformUtil.transform(
+				ListUtil.fromArray(_INFO_FIELDS), InfoField::getUniqueId);
+
+			JSONObject updateFormJSONObject = ReflectionTestUtil.invoke(
+				_mvcActionCommand, "doTransactionalCommand",
+				new Class<?>[] {ActionRequest.class, ActionResponse.class},
+				_getMockLiferayPortletActionRequest(
+					StringUtil.merge(fields),
+					JSONUtil.put(
+						"classNameId", classNameId
+					).put(
+						"classTypeId", "0"
+					).toString(),
+					formItemId, _layout),
+				new MockLiferayPortletActionResponse());
+
+			_assertUpdateFormStyledLayoutStructureItemConfigJSONObject(
+				updateFormJSONObject, 0, StringPool.BLANK, StringPool.BLANK, 2);
+
+			_assertFormStyledLayoutStructureItem(
+				classNameId, _INFO_FIELDS.length + 1, formItemId, allInfoFields,
+				true, false);
+		}
+	}
+
+	@FeatureFlags("LPD-20213")
+	@Test
 	public void testUpdateFormItemConfigMVCActionCommandMappingFormWithEmptySpecificField()
 		throws Exception {
 

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/UpdateFormItemConfigMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/UpdateFormItemConfigMVCActionCommandTest.java
@@ -69,6 +69,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -151,7 +152,8 @@ public class UpdateFormItemConfigMVCActionCommandTest {
 		};
 
 		InfoField<?>[] allInfoFields = ArrayUtil.append(
-			_INFO_FIELDS, _getInfoField(infoFieldType));
+			_INFO_FIELDS,
+			_getInfoField(infoFieldType, RandomTestUtil.randomString()));
 
 		try (ComponentEnablerTemporarySwapper componentEnablerTemporarySwapper =
 				new ComponentEnablerTemporarySwapper(
@@ -179,6 +181,7 @@ public class UpdateFormItemConfigMVCActionCommandTest {
 				_mvcActionCommand, "_updateFormStyledLayoutStructureItemConfig",
 				new Class<?>[] {ActionRequest.class, ActionResponse.class},
 				_getMockLiferayPortletActionRequest(
+					null,
 					JSONUtil.put(
 						"classNameId", classNameId
 					).put(
@@ -232,6 +235,7 @@ public class UpdateFormItemConfigMVCActionCommandTest {
 				_mvcActionCommand, "_updateFormStyledLayoutStructureItemConfig",
 				new Class<?>[] {ActionRequest.class, ActionResponse.class},
 				_getMockLiferayPortletActionRequest(
+					null,
 					JSONUtil.put(
 						"classNameId", classNameId
 					).put(
@@ -283,6 +287,7 @@ public class UpdateFormItemConfigMVCActionCommandTest {
 				_mvcActionCommand, "_updateFormStyledLayoutStructureItemConfig",
 				new Class<?>[] {ActionRequest.class, ActionResponse.class},
 				_getMockLiferayPortletActionRequest(
+					null,
 					JSONUtil.put(
 						"classNameId", classNameId
 					).put(
@@ -298,6 +303,158 @@ public class UpdateFormItemConfigMVCActionCommandTest {
 			_assertFormStyledLayoutStructureItem(
 				classNameId, _INFO_FIELDS.length + 1, formItemId, _INFO_FIELDS,
 				true, true);
+		}
+	}
+
+	@FeatureFlags("LPD-20213")
+	@Test
+	public void testUpdateFormItemConfigMVCActionCommandMappingFormWithEmptySpecificField()
+		throws Exception {
+
+		try (ComponentEnablerTemporarySwapper componentEnablerTemporarySwapper =
+				new ComponentEnablerTemporarySwapper(
+					_BUNDLE_SYMBOLIC_NAME, _COMPONENT_CLASS_NAME, true);
+			MockInfoServiceRegistrationHolder
+				mockInfoServiceRegistrationHolder =
+					new MockInfoServiceRegistrationHolder(
+						InfoFieldSet.builder(
+						).infoFieldSetEntries(
+							ListUtil.fromArray(_INFO_FIELDS)
+						).build(),
+						_portal, _editPageInfoItemCapability)) {
+
+			JSONObject addItemJSONObject =
+				ContentLayoutTestUtil.addItemToLayout(
+					"{}", LayoutDataItemTypeConstants.TYPE_FORM, _layout,
+					_layoutStructureProvider, _segmentsExperienceId);
+
+			long classNameId = _portal.getClassNameId(
+				MockObject.class.getName());
+
+			String formItemId = addItemJSONObject.getString("addedItemId");
+
+			JSONObject updateFormJSONObject = ReflectionTestUtil.invoke(
+				_mvcActionCommand, "_updateFormStyledLayoutStructureItemConfig",
+				new Class<?>[] {ActionRequest.class, ActionResponse.class},
+				_getMockLiferayPortletActionRequest(
+					null,
+					JSONUtil.put(
+						"classNameId", classNameId
+					).put(
+						"classTypeId", "0"
+					).toString(),
+					formItemId, _layout),
+				new MockLiferayPortletActionResponse());
+
+			_assertUpdateFormStyledLayoutStructureItemConfigJSONObject(
+				updateFormJSONObject, 0, StringPool.BLANK, StringPool.BLANK, 0);
+
+			_assertFormStyledLayoutStructureItem(
+				classNameId, 0, formItemId, new InfoField<?>[0], true, false);
+		}
+	}
+
+	@Test
+	public void testUpdateFormItemConfigMVCActionCommandMappingFormWithNonexistingSpecificField()
+		throws Exception {
+
+		try (ComponentEnablerTemporarySwapper componentEnablerTemporarySwapper =
+				new ComponentEnablerTemporarySwapper(
+					_BUNDLE_SYMBOLIC_NAME, _COMPONENT_CLASS_NAME, true);
+			MockInfoServiceRegistrationHolder
+				mockInfoServiceRegistrationHolder =
+					new MockInfoServiceRegistrationHolder(
+						InfoFieldSet.builder(
+						).infoFieldSetEntries(
+							ListUtil.fromArray(_INFO_FIELDS)
+						).build(),
+						_portal, _editPageInfoItemCapability)) {
+
+			JSONObject addItemJSONObject =
+				ContentLayoutTestUtil.addItemToLayout(
+					"{}", LayoutDataItemTypeConstants.TYPE_FORM, _layout,
+					_layoutStructureProvider, _segmentsExperienceId);
+
+			long classNameId = _portal.getClassNameId(
+				MockObject.class.getName());
+
+			String formItemId = addItemJSONObject.getString("addedItemId");
+
+			JSONObject updateFormJSONObject = ReflectionTestUtil.invoke(
+				_mvcActionCommand, "_updateFormStyledLayoutStructureItemConfig",
+				new Class<?>[] {ActionRequest.class, ActionResponse.class},
+				_getMockLiferayPortletActionRequest(
+					RandomTestUtil.randomString(),
+					JSONUtil.put(
+						"classNameId", classNameId
+					).put(
+						"classTypeId", "0"
+					).toString(),
+					formItemId, _layout),
+				new MockLiferayPortletActionResponse());
+
+			_assertUpdateFormStyledLayoutStructureItemConfigJSONObject(
+				updateFormJSONObject, 1, StringPool.BLANK, StringPool.BLANK, 0);
+
+			_assertFormStyledLayoutStructureItem(
+				classNameId, 1, formItemId, new InfoField<?>[0], true, true);
+		}
+	}
+
+	@Test
+	public void testUpdateFormItemConfigMVCActionCommandMappingFormWithSpecificFields()
+		throws Exception {
+
+		InfoField<?>[] customInfoFields = new InfoField<?>[] {
+			_getInfoField(BooleanInfoFieldType.INSTANCE, "custom-boolean"),
+			_getInfoField(TextInfoFieldType.INSTANCE, "custom-text")
+		};
+
+		InfoField<?>[] allInfoFields = ArrayUtil.append(
+			_INFO_FIELDS, customInfoFields);
+
+		try (ComponentEnablerTemporarySwapper componentEnablerTemporarySwapper =
+				new ComponentEnablerTemporarySwapper(
+					_BUNDLE_SYMBOLIC_NAME, _COMPONENT_CLASS_NAME, true);
+			MockInfoServiceRegistrationHolder
+				mockInfoServiceRegistrationHolder =
+					new MockInfoServiceRegistrationHolder(
+						InfoFieldSet.builder(
+						).infoFieldSetEntries(
+							ListUtil.fromArray(allInfoFields)
+						).build(),
+						_portal, _editPageInfoItemCapability)) {
+
+			JSONObject addItemJSONObject =
+				ContentLayoutTestUtil.addItemToLayout(
+					"{}", LayoutDataItemTypeConstants.TYPE_FORM, _layout,
+					_layoutStructureProvider, _segmentsExperienceId);
+
+			long classNameId = _portal.getClassNameId(
+				MockObject.class.getName());
+
+			String formItemId = addItemJSONObject.getString("addedItemId");
+
+			JSONObject updateFormJSONObject = ReflectionTestUtil.invoke(
+				_mvcActionCommand, "_updateFormStyledLayoutStructureItemConfig",
+				new Class<?>[] {ActionRequest.class, ActionResponse.class},
+				_getMockLiferayPortletActionRequest(
+					"custom-boolean,custom-text",
+					JSONUtil.put(
+						"classNameId", classNameId
+					).put(
+						"classTypeId", "0"
+					).toString(),
+					formItemId, _layout),
+				new MockLiferayPortletActionResponse());
+
+			_assertUpdateFormStyledLayoutStructureItemConfigJSONObject(
+				updateFormJSONObject, customInfoFields.length + 1,
+				StringPool.BLANK, StringPool.BLANK, 0);
+
+			_assertFormStyledLayoutStructureItem(
+				classNameId, customInfoFields.length + 1, formItemId,
+				customInfoFields, true, true);
 		}
 	}
 
@@ -341,7 +498,8 @@ public class UpdateFormItemConfigMVCActionCommandTest {
 		InfoField<?>[] allInfoFields = ArrayUtil.append(
 			_INFO_FIELDS,
 			new InfoField<?>[] {
-				_getInfoField(infoFieldType1), _getInfoField(infoFieldType2)
+				_getInfoField(infoFieldType1, RandomTestUtil.randomString()),
+				_getInfoField(infoFieldType2, RandomTestUtil.randomString())
 			});
 
 		try (ComponentEnablerTemporarySwapper componentEnablerTemporarySwapper =
@@ -370,6 +528,7 @@ public class UpdateFormItemConfigMVCActionCommandTest {
 				_mvcActionCommand, "_updateFormStyledLayoutStructureItemConfig",
 				new Class<?>[] {ActionRequest.class, ActionResponse.class},
 				_getMockLiferayPortletActionRequest(
+					null,
 					JSONUtil.put(
 						"classNameId", classNameId
 					).put(
@@ -431,6 +590,7 @@ public class UpdateFormItemConfigMVCActionCommandTest {
 				_mvcActionCommand, "_updateFormStyledLayoutStructureItemConfig",
 				new Class<?>[] {ActionRequest.class, ActionResponse.class},
 				_getMockLiferayPortletActionRequest(
+					null,
 					JSONUtil.put(
 						"successMessage",
 						JSONUtil.put(
@@ -485,6 +645,7 @@ public class UpdateFormItemConfigMVCActionCommandTest {
 				_mvcActionCommand, "_updateFormStyledLayoutStructureItemConfig",
 				new Class<?>[] {ActionRequest.class, ActionResponse.class},
 				_getMockLiferayPortletActionRequest(
+					null,
 					JSONUtil.put(
 						"classNameId", "0"
 					).put(
@@ -503,13 +664,13 @@ public class UpdateFormItemConfigMVCActionCommandTest {
 	}
 
 	private static <T extends InfoFieldType> InfoField<T> _getInfoField(
-		T infoFieldTypeInstance) {
+		T infoFieldTypeInstance, String uniqueId) {
 
 		return InfoField.builder(
 		).infoFieldType(
 			infoFieldTypeInstance
-		).namespace(
-			RandomTestUtil.randomString()
+		).uniqueId(
+			uniqueId
 		).name(
 			RandomTestUtil.randomString()
 		).editable(
@@ -679,13 +840,14 @@ public class UpdateFormItemConfigMVCActionCommandTest {
 	}
 
 	private MockLiferayPortletActionRequest _getMockLiferayPortletActionRequest(
-			String itemConfig, String formItemId, Layout layout)
+			String fields, String itemConfig, String formItemId, Layout layout)
 		throws Exception {
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			ContentLayoutTestUtil.getMockLiferayPortletActionRequest(
 				_company, _group, layout);
 
+		mockLiferayPortletActionRequest.addParameter("fields", fields);
 		mockLiferayPortletActionRequest.addParameter("itemConfig", itemConfig);
 		mockLiferayPortletActionRequest.addParameter("itemId", formItemId);
 		mockLiferayPortletActionRequest.addParameter(
@@ -731,13 +893,19 @@ public class UpdateFormItemConfigMVCActionCommandTest {
 			"InputsFragmentCollectionContributor";
 
 	private static final InfoField<?>[] _INFO_FIELDS = new InfoField<?>[] {
-		_getInfoField(BooleanInfoFieldType.INSTANCE),
-		_getInfoField(DateInfoFieldType.INSTANCE),
-		_getInfoField(FileInfoFieldType.INSTANCE),
-		_getInfoField(NumberInfoFieldType.INSTANCE),
-		_getInfoField(RelationshipInfoFieldType.INSTANCE),
-		_getInfoField(SelectInfoFieldType.INSTANCE),
-		_getInfoField(TextInfoFieldType.INSTANCE)
+		_getInfoField(
+			BooleanInfoFieldType.INSTANCE, RandomTestUtil.randomString()),
+		_getInfoField(
+			DateInfoFieldType.INSTANCE, RandomTestUtil.randomString()),
+		_getInfoField(
+			FileInfoFieldType.INSTANCE, RandomTestUtil.randomString()),
+		_getInfoField(
+			NumberInfoFieldType.INSTANCE, RandomTestUtil.randomString()),
+		_getInfoField(
+			RelationshipInfoFieldType.INSTANCE, RandomTestUtil.randomString()),
+		_getInfoField(
+			SelectInfoFieldType.INSTANCE, RandomTestUtil.randomString()),
+		_getInfoField(TextInfoFieldType.INSTANCE, RandomTestUtil.randomString())
 	};
 
 	private Company _company;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -503,6 +503,11 @@ public class ContentPageEditorDisplayContext {
 				_getResourceURL(
 					"/layout_content_page_editor/get_info_item_field_value")
 			).put(
+				"getInfoItemOneToManyRelationshipsURL",
+				_getResourceURL(
+					"/layout_content_page_editor" +
+						"/get_info_item_one_to_many_relationships")
+			).put(
 				"getLayoutFriendlyURL",
 				_getResourceURL(
 					"/layout_content_page_editor/get_layout_friendly_url")

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/manager/FormItemManager.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/manager/FormItemManager.java
@@ -61,7 +61,8 @@ public class FormItemManager {
 	public List<FragmentEntryLink> addFragmentEntryLinks(
 			JSONObject errorJSONObject, String[] infoFieldUniqueIds,
 			FormStyledLayoutStructureItem formStyledLayoutStructureItem,
-			Layout layout, LayoutStructure layoutStructure, Locale locale,
+			boolean includeSubmitButton, Layout layout,
+			LayoutStructure layoutStructure, Locale locale,
 			long segmentsExperienceId, ServiceContext serviceContext)
 		throws PortalException {
 
@@ -124,24 +125,26 @@ public class FormItemManager {
 					serviceContext));
 		}
 
-		FragmentEntry fragmentEntry = _getFragmentEntry(
-			layout.getCompanyId(), defaultInputFragmentEntryKeysJSONObject,
-			DefaultInputFragmentEntryConfigurationProvider.
-				FORM_INPUT_SUBMIT_BUTTON);
+		if (includeSubmitButton) {
+			FragmentEntry fragmentEntry = _getFragmentEntry(
+				layout.getCompanyId(), defaultInputFragmentEntryKeysJSONObject,
+				DefaultInputFragmentEntryConfigurationProvider.
+					FORM_INPUT_SUBMIT_BUTTON);
 
-		if ((fragmentEntry == null) ||
-			!_isAllowedFragmentEntryKey(
-				fragmentEntry.getFragmentEntryKey(),
-				masterDropZoneLayoutStructureItem)) {
+			if ((fragmentEntry == null) ||
+				!_isAllowedFragmentEntryKey(
+					fragmentEntry.getFragmentEntryKey(),
+					masterDropZoneLayoutStructureItem)) {
 
-			missingInputTypes.add(_language.get(locale, "submit-button"));
-		}
-		else {
-			addedFragmentEntryLinks.add(
-				_addFragmentEntryLink(
-					formStyledLayoutStructureItem.getItemId(), fragmentEntry,
-					null, layout, layoutStructure, segmentsExperienceId,
-					serviceContext));
+				missingInputTypes.add(_language.get(locale, "submit-button"));
+			}
+			else {
+				addedFragmentEntryLinks.add(
+					_addFragmentEntryLink(
+						formStyledLayoutStructureItem.getItemId(),
+						fragmentEntry, null, layout, layoutStructure,
+						segmentsExperienceId, serviceContext));
+			}
 		}
 
 		if (missingInputTypes.size() == 1) {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/manager/FormItemManager.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/manager/FormItemManager.java
@@ -177,7 +177,7 @@ public class FormItemManager {
 
 	public JSONArray removeLayoutStructureItemsJSONArray(
 		FormStyledLayoutStructureItem formStyledLayoutStructureItem,
-		LayoutStructure layoutStructure) {
+		LayoutStructure layoutStructure, List<String> removedItemIds) {
 
 		JSONArray fragmentEntryLinkIdsJSONArray =
 			_jsonFactory.createJSONArray();
@@ -185,6 +185,12 @@ public class FormItemManager {
 		for (String itemId :
 				ListUtil.copy(
 					formStyledLayoutStructureItem.getChildrenItemIds())) {
+
+			if (ListUtil.isNotEmpty(removedItemIds) &&
+				!removedItemIds.contains(itemId)) {
+
+				continue;
+			}
 
 			layoutStructure.markLayoutStructureItemForDeletion(
 				itemId, Collections.emptyList());

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/manager/FormItemManager.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/manager/FormItemManager.java
@@ -37,6 +37,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -58,7 +59,7 @@ import org.osgi.service.component.annotations.Reference;
 public class FormItemManager {
 
 	public List<FragmentEntryLink> addFragmentEntryLinks(
-			JSONObject errorJSONObject,
+			JSONObject errorJSONObject, String[] infoFieldUniqueIds,
 			FormStyledLayoutStructureItem formStyledLayoutStructureItem,
 			Layout layout, LayoutStructure layoutStructure, Locale locale,
 			long segmentsExperienceId, ServiceContext serviceContext)
@@ -92,7 +93,11 @@ public class FormItemManager {
 				_getInfoFields(
 					formStyledLayoutStructureItem, layout.getGroupId())) {
 
-			if (!infoField.isEditable()) {
+			if (!infoField.isEditable() ||
+				(ArrayUtil.isNotEmpty(infoFieldUniqueIds) &&
+				 !ArrayUtil.contains(
+					 infoFieldUniqueIds, infoField.getUniqueId()))) {
+
 				continue;
 			}
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/model/listener/LayoutPageTemplateEntryModelListener.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/model/listener/LayoutPageTemplateEntryModelListener.java
@@ -209,9 +209,10 @@ public class LayoutPageTemplateEntryModelListener
 				UpdateLayoutStatusThreadLocal.setWithSafeCloseable(false)) {
 
 			return _formItemManager.addFragmentEntryLinks(
-				_jsonFactory.createJSONObject(), formStyledLayoutStructureItem,
-				layout, layoutStructure, LocaleUtil.getMostRelevantLocale(),
-				segmentsExperienceId, serviceContext);
+				_jsonFactory.createJSONObject(), null,
+				formStyledLayoutStructureItem, layout, layoutStructure,
+				LocaleUtil.getMostRelevantLocale(), segmentsExperienceId,
+				serviceContext);
 		}
 		catch (PortalException portalException) {
 			if (_log.isDebugEnabled()) {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/model/listener/LayoutPageTemplateEntryModelListener.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/model/listener/LayoutPageTemplateEntryModelListener.java
@@ -210,7 +210,7 @@ public class LayoutPageTemplateEntryModelListener
 
 			return _formItemManager.addFragmentEntryLinks(
 				_jsonFactory.createJSONObject(), null,
-				formStyledLayoutStructureItem, layout, layoutStructure,
+				formStyledLayoutStructureItem, true, layout, layoutStructure,
 				LocaleUtil.getMostRelevantLocale(), segmentsExperienceId,
 				serviceContext);
 		}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/model/listener/LayoutPageTemplateEntryModelListener.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/model/listener/LayoutPageTemplateEntryModelListener.java
@@ -138,7 +138,7 @@ public class LayoutPageTemplateEntryModelListener
 		}
 
 		_formItemManager.removeLayoutStructureItemsJSONArray(
-			formStyledLayoutStructureItem, layoutStructure);
+			formStyledLayoutStructureItem, layoutStructure, null);
 
 		formStyledLayoutStructureItem.setClassNameId(0);
 		formStyledLayoutStructureItem.setClassTypeId(0);

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetInfoItemOneToManyRelationshipsMVCResourceCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetInfoItemOneToManyRelationshipsMVCResourceCommand.java
@@ -1,0 +1,113 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.content.page.editor.web.internal.portlet.action;
+
+import com.liferay.info.item.InfoItemClassDetails;
+import com.liferay.info.item.InfoItemServiceRegistry;
+import com.liferay.info.item.provider.InfoItemDetailsProvider;
+import com.liferay.info.item.provider.RelatedInfoItemProvider;
+import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.ClassName;
+import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import javax.portlet.ResourceRequest;
+import javax.portlet.ResourceResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Eudaldo Alonso
+ */
+@Component(
+	property = {
+		"javax.portlet.name=" + ContentPageEditorPortletKeys.CONTENT_PAGE_EDITOR_PORTLET,
+		"mvc.command.name=/layout_content_page_editor/get_info_item_one_to_many_relationships"
+	},
+	service = MVCResourceCommand.class
+)
+public class GetInfoItemOneToManyRelationshipsMVCResourceCommand
+	extends BaseMVCResourceCommand {
+
+	@Override
+	protected void doServeResource(
+			ResourceRequest resourceRequest, ResourceResponse resourceResponse)
+		throws Exception {
+
+		long classNameId = ParamUtil.getLong(resourceRequest, "classNameId");
+
+		ClassName className = _classNameLocalService.fetchClassName(
+			classNameId);
+
+		if (className == null) {
+			JSONPortletResponseUtil.writeJSON(
+				resourceRequest, resourceResponse,
+				_jsonFactory.createJSONArray());
+
+			return;
+		}
+
+		RelatedInfoItemProvider<?> relatedInfoItemProvider =
+			_infoItemServiceRegistry.getFirstInfoItemService(
+				RelatedInfoItemProvider.class, className.getValue());
+
+		if (relatedInfoItemProvider == null) {
+			JSONPortletResponseUtil.writeJSON(
+				resourceRequest, resourceResponse,
+				_jsonFactory.createJSONArray());
+
+			return;
+		}
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)resourceRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		JSONArray jsonArray = _jsonFactory.createJSONArray();
+
+		for (String relatedItemClassName :
+				relatedInfoItemProvider.getRelatedItemClassNames()) {
+
+			InfoItemDetailsProvider<?> infoItemDetailsProvider =
+				_infoItemServiceRegistry.getFirstInfoItemService(
+					InfoItemDetailsProvider.class, relatedItemClassName);
+
+			InfoItemClassDetails infoItemClassDetails =
+				infoItemDetailsProvider.getInfoItemClassDetails();
+
+			jsonArray.put(
+				JSONUtil.put(
+					"classNameId",
+					_classNameLocalService.getClassNameId(
+						infoItemClassDetails.getClassName())
+				).put(
+					"label",
+					infoItemClassDetails.getLabel(themeDisplay.getLocale())
+				));
+		}
+
+		JSONPortletResponseUtil.writeJSON(
+			resourceRequest, resourceResponse, jsonArray);
+	}
+
+	@Reference
+	private ClassNameLocalService _classNameLocalService;
+
+	@Reference
+	private InfoItemServiceRegistry _infoItemServiceRegistry;
+
+	@Reference
+	private JSONFactory _jsonFactory;
+
+}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/UpdateFormItemConfigMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/UpdateFormItemConfigMVCActionCommand.java
@@ -16,14 +16,17 @@ import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocal
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureService;
 import com.liferay.layout.util.structure.FormStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructure;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.ArrayList;
@@ -116,12 +119,21 @@ public class UpdateFormItemConfigMVCActionCommand
 					formStyledLayoutStructureItem, layoutStructure);
 
 			if (formStyledLayoutStructureItem.getClassNameId() > 0) {
-				addedFragmentEntryLinks =
-					_formItemManager.addFragmentEntryLinks(
-						jsonObject, formStyledLayoutStructureItem,
-						themeDisplay.getLayout(), layoutStructure,
-						themeDisplay.getLocale(), segmentsExperienceId,
-						ServiceContextFactory.getInstance(httpServletRequest));
+				String[] infoFieldUniqueIds = StringUtil.split(
+					ParamUtil.getString(actionRequest, "fields"));
+
+				if (!FeatureFlagManagerUtil.isEnabled("LPD-20213") ||
+					ArrayUtil.isNotEmpty(infoFieldUniqueIds)) {
+
+					addedFragmentEntryLinks =
+						_formItemManager.addFragmentEntryLinks(
+							jsonObject, infoFieldUniqueIds,
+							formStyledLayoutStructureItem,
+							themeDisplay.getLayout(), layoutStructure,
+							themeDisplay.getLocale(), segmentsExperienceId,
+							ServiceContextFactory.getInstance(
+								httpServletRequest));
+				}
 			}
 		}
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/UpdateFormItemConfigMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/UpdateFormItemConfigMVCActionCommand.java
@@ -38,8 +38,11 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
@@ -72,11 +75,11 @@ public class UpdateFormItemConfigMVCActionCommand
 			actionRequest, actionResponse);
 	}
 
-	private String[] _getCurrentUniqueFieldIds(
+	private Map<String, String> _getCurrentInputFields(
 		FormStyledLayoutStructureItem formStyledLayoutStructureItem,
 		LayoutStructure layoutStructure, ThemeDisplay themeDisplay) {
 
-		List<String> fieldNames = new ArrayList<>();
+		Map<String, String> inputFields = new HashMap<>();
 
 		for (String itemId :
 				formStyledLayoutStructureItem.getChildrenItemIds()) {
@@ -104,11 +107,12 @@ public class UpdateFormItemConfigMVCActionCommand
 					themeDisplay.getLocale()));
 
 			if (Validator.isNotNull(fieldName)) {
-				fieldNames.add(fieldName);
+				inputFields.put(
+					fieldName, fragmentStyledLayoutStructureItem.getItemId());
 			}
 		}
 
-		return fieldNames.toArray(new String[0]);
+		return inputFields;
 	}
 
 	private JSONObject _updateFormStyledLayoutStructureItemConfig(
@@ -163,7 +167,7 @@ public class UpdateFormItemConfigMVCActionCommand
 
 			removedLayoutStructureItemsJSONArray =
 				_formItemManager.removeLayoutStructureItemsJSONArray(
-					formStyledLayoutStructureItem, layoutStructure);
+					formStyledLayoutStructureItem, layoutStructure, null);
 
 			if (formStyledLayoutStructureItem.getClassNameId() > 0) {
 				String[] infoFieldUniqueIds = StringUtil.split(
@@ -189,16 +193,19 @@ public class UpdateFormItemConfigMVCActionCommand
 
 				List<String> newInfoUniqueFieldIds = new ArrayList<>();
 
-				String[] currentInfoUniqueFieldIds = _getCurrentUniqueFieldIds(
+				Map<String, String> currentInputFields = _getCurrentInputFields(
 					formStyledLayoutStructureItem, layoutStructure,
 					themeDisplay);
+
+				Set<String> currentInfoFieldUniqueIds =
+					currentInputFields.keySet();
 
 				String[] infoFieldUniqueIds = StringUtil.split(
 					ParamUtil.getString(actionRequest, "fields"));
 
 				for (String infoFieldUniqueId : infoFieldUniqueIds) {
-					if (!ArrayUtil.contains(
-							currentInfoUniqueFieldIds, infoFieldUniqueId)) {
+					if (!currentInfoFieldUniqueIds.contains(
+							infoFieldUniqueId)) {
 
 						newInfoUniqueFieldIds.add(infoFieldUniqueId);
 					}
@@ -214,6 +221,26 @@ public class UpdateFormItemConfigMVCActionCommand
 							themeDisplay.getLocale(), segmentsExperienceId,
 							ServiceContextFactory.getInstance(
 								httpServletRequest));
+				}
+
+				List<String> removedItemIds = new ArrayList<>();
+
+				for (String currentInfoFieldUniqueId :
+						currentInfoFieldUniqueIds) {
+
+					if (!ArrayUtil.contains(
+							infoFieldUniqueIds, currentInfoFieldUniqueId)) {
+
+						removedItemIds.add(
+							currentInputFields.get(currentInfoFieldUniqueId));
+					}
+				}
+
+				if (ListUtil.isNotEmpty(removedItemIds)) {
+					removedLayoutStructureItemsJSONArray =
+						_formItemManager.removeLayoutStructureItemsJSONArray(
+							formStyledLayoutStructureItem, layoutStructure,
+							removedItemIds);
 				}
 			}
 		}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/UpdateFormItemConfigMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/UpdateFormItemConfigMVCActionCommand.java
@@ -175,7 +175,7 @@ public class UpdateFormItemConfigMVCActionCommand
 					addedFragmentEntryLinks =
 						_formItemManager.addFragmentEntryLinks(
 							jsonObject, infoFieldUniqueIds,
-							formStyledLayoutStructureItem,
+							formStyledLayoutStructureItem, true,
 							themeDisplay.getLayout(), layoutStructure,
 							themeDisplay.getLocale(), segmentsExperienceId,
 							ServiceContextFactory.getInstance(
@@ -209,7 +209,7 @@ public class UpdateFormItemConfigMVCActionCommand
 						_formItemManager.addFragmentEntryLinks(
 							jsonObject,
 							newInfoUniqueFieldIds.toArray(new String[0]),
-							formStyledLayoutStructureItem,
+							formStyledLayoutStructureItem, false,
 							themeDisplay.getLayout(), layoutStructure,
 							themeDisplay.getLocale(), segmentsExperienceId,
 							ServiceContextFactory.getInstance(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/UpdateFormItemConfigMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/UpdateFormItemConfigMVCActionCommand.java
@@ -8,6 +8,9 @@ package com.liferay.layout.content.page.editor.web.internal.portlet.action;
 import com.liferay.fragment.listener.FragmentEntryLinkListener;
 import com.liferay.fragment.listener.FragmentEntryLinkListenerRegistry;
 import com.liferay.fragment.model.FragmentEntryLink;
+import com.liferay.fragment.service.FragmentEntryLinkLocalService;
+import com.liferay.fragment.util.configuration.FragmentConfigurationField;
+import com.liferay.fragment.util.configuration.FragmentEntryConfigurationParser;
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
 import com.liferay.layout.content.page.editor.web.internal.manager.FormItemManager;
 import com.liferay.layout.content.page.editor.web.internal.manager.FragmentEntryLinkManager;
@@ -15,7 +18,9 @@ import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureService;
 import com.liferay.layout.util.structure.FormStyledLayoutStructureItem;
+import com.liferay.layout.util.structure.FragmentStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructure;
+import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
@@ -24,9 +29,12 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.ArrayList;
@@ -62,6 +70,45 @@ public class UpdateFormItemConfigMVCActionCommand
 
 		return _updateFormStyledLayoutStructureItemConfig(
 			actionRequest, actionResponse);
+	}
+
+	private String[] _getCurrentUniqueFieldIds(
+		FormStyledLayoutStructureItem formStyledLayoutStructureItem,
+		LayoutStructure layoutStructure, ThemeDisplay themeDisplay) {
+
+		List<String> fieldNames = new ArrayList<>();
+
+		for (String itemId :
+				formStyledLayoutStructureItem.getChildrenItemIds()) {
+
+			LayoutStructureItem layoutStructureItem =
+				layoutStructure.getLayoutStructureItem(itemId);
+
+			FragmentStyledLayoutStructureItem
+				fragmentStyledLayoutStructureItem =
+					(FragmentStyledLayoutStructureItem)layoutStructureItem;
+
+			FragmentEntryLink fragmentEntryLink =
+				_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
+					fragmentStyledLayoutStructureItem.getFragmentEntryLinkId());
+
+			if (fragmentEntryLink == null) {
+				continue;
+			}
+
+			String fieldName = GetterUtil.getString(
+				_fragmentEntryConfigurationParser.getFieldValue(
+					fragmentEntryLink.getEditableValues(),
+					new FragmentConfigurationField(
+						"inputFieldId", "string", "", false, "text"),
+					themeDisplay.getLocale()));
+
+			if (Validator.isNotNull(fieldName)) {
+				fieldNames.add(fieldName);
+			}
+		}
+
+		return fieldNames.toArray(new String[0]);
 	}
 
 	private JSONObject _updateFormStyledLayoutStructureItemConfig(
@@ -136,6 +183,40 @@ public class UpdateFormItemConfigMVCActionCommand
 				}
 			}
 		}
+		else {
+			if (FeatureFlagManagerUtil.isEnabled("LPD-20213") &&
+				(formStyledLayoutStructureItem.getClassNameId() > 0)) {
+
+				List<String> newInfoUniqueFieldIds = new ArrayList<>();
+
+				String[] currentInfoUniqueFieldIds = _getCurrentUniqueFieldIds(
+					formStyledLayoutStructureItem, layoutStructure,
+					themeDisplay);
+
+				String[] infoFieldUniqueIds = StringUtil.split(
+					ParamUtil.getString(actionRequest, "fields"));
+
+				for (String infoFieldUniqueId : infoFieldUniqueIds) {
+					if (!ArrayUtil.contains(
+							currentInfoUniqueFieldIds, infoFieldUniqueId)) {
+
+						newInfoUniqueFieldIds.add(infoFieldUniqueId);
+					}
+				}
+
+				if (ListUtil.isNotEmpty(newInfoUniqueFieldIds)) {
+					addedFragmentEntryLinks =
+						_formItemManager.addFragmentEntryLinks(
+							jsonObject,
+							newInfoUniqueFieldIds.toArray(new String[0]),
+							formStyledLayoutStructureItem,
+							themeDisplay.getLayout(), layoutStructure,
+							themeDisplay.getLocale(), segmentsExperienceId,
+							ServiceContextFactory.getInstance(
+								httpServletRequest));
+				}
+			}
+		}
 
 		layoutPageTemplateStructure =
 			_layoutPageTemplateStructureService.
@@ -187,8 +268,14 @@ public class UpdateFormItemConfigMVCActionCommand
 	private FormItemManager _formItemManager;
 
 	@Reference
+	private FragmentEntryConfigurationParser _fragmentEntryConfigurationParser;
+
+	@Reference
 	private FragmentEntryLinkListenerRegistry
 		_fragmentEntryLinkListenerRegistry;
+
+	@Reference
+	private FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;
 
 	@Reference
 	private FragmentEntryLinkManager _fragmentEntryLinkManager;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/layout_data_items/FormWithControls.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/layout_data_items/FormWithControls.js
@@ -110,7 +110,7 @@ function FormEmptyState({isMapped, item}) {
 	const updateItemLocalConfig = useUpdateItemLocalConfig();
 
 	const onValueSelect = useCallback(
-		(nextConfig) => {
+		(nextConfig, fields) => {
 			const isMapping = Boolean(nextConfig.classNameId);
 
 			if (isMapping) {
@@ -121,6 +121,7 @@ function FormEmptyState({isMapped, item}) {
 
 			dispatch(
 				updateFormItemConfig({
+					fields,
 					itemConfig: nextConfig,
 					itemId: item.itemId,
 				})

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/services/FormService.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/services/FormService.ts
@@ -66,11 +66,13 @@ export default {
 	},
 
 	updateFormItemConfig({
+		fields,
 		itemConfig,
 		itemId,
 		onNetworkStatus,
 		segmentsExperienceId,
 	}: {
+		fields: string[];
 		itemConfig: FormLayoutDataItem['config'];
 		itemId: string;
 		onNetworkStatus: OnNetworkStatus;
@@ -85,6 +87,7 @@ export default {
 			config.updateFormItemConfigURL,
 			{
 				body: {
+					fields,
 					itemConfig: JSON.stringify(itemConfig),
 					itemId,
 					segmentsExperienceId,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/updateFormItemConfig.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/updateFormItemConfig.js
@@ -8,11 +8,12 @@ import {openToast} from 'frontend-js-web';
 import updateFormItemConfigAction from '../actions/updateFormItemConfig';
 import FormService from '../services/FormService';
 
-export default function updateFormItemConfig({itemConfig, itemId}) {
+export default function updateFormItemConfig({fields, itemConfig, itemId}) {
 	const isMapping = Boolean(itemConfig.classNameId);
 
 	return (dispatch, getState) => {
 		return FormService.updateFormItemConfig({
+			fields,
 			itemConfig,
 			itemId,
 			onNetworkStatus: dispatch,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/openInfoFieldSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/openInfoFieldSelector.js
@@ -7,12 +7,20 @@ import {getPortletNamespace, openSelectionModal} from 'frontend-js-web';
 
 import {config} from '../app/config/index';
 
-export function openInfoFieldSelector({itemType, onCancel, onSave}) {
+export function openInfoFieldSelector({formItemId, itemType, onCancel, onSave, segmentsExperienceId}) {
 	const url = new URL(config.infoFieldItemSelectorURL);
 
 	url.searchParams.set(
+		`${getPortletNamespace(Liferay.PortletKeys.ITEM_SELECTOR)}formItemId`,
+		formItemId
+	);
+	url.searchParams.set(
 		`${getPortletNamespace(Liferay.PortletKeys.ITEM_SELECTOR)}itemType`,
 		itemType
+	);
+	url.searchParams.set(
+		`${getPortletNamespace(Liferay.PortletKeys.ITEM_SELECTOR)}segmentsExperienceId`,
+		segmentsExperienceId
 	);
 
 	openSelectionModal({

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/FormGeneralPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/FormGeneralPanel.js
@@ -44,7 +44,7 @@ export function FormGeneralPanel({item}) {
 	const updateItemLocalConfig = useUpdateItemLocalConfig();
 
 	const onValueSelect = useCallback(
-		(nextConfig) => {
+		(nextConfig, fields) => {
 			const isMapping = Boolean(nextConfig.classNameId);
 
 			if (isMapping) {
@@ -56,6 +56,7 @@ export function FormGeneralPanel({item}) {
 
 			dispatch(
 				updateFormItemConfig({
+					fields,
 					itemConfig: nextConfig,
 					itemId: item.itemId,
 				})

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/FormMappingOptions.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/FormMappingOptions.js
@@ -42,12 +42,14 @@ export default function FormMappingOptions({
 			};
 
 			const saveMapping = (fields = []) =>
-				onValueSelect({
-					classNameId,
-					classTypeId,
-					fields: fields.map(({uniqueId}) => uniqueId),
-					formConfig: FORM_MAPPING_SOURCES.otherContentType,
-				});
+				onValueSelect(
+					{
+						classNameId,
+						classTypeId,
+						formConfig: FORM_MAPPING_SOURCES.otherContentType,
+					},
+					fields.map(({uniqueId}) => uniqueId)
+				);
 
 			if (Liferay.FeatureFlags['LPD-20213'] && classNameId !== '0') {
 				openInfoFieldSelector({

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/FormMappingOptions.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/FormMappingOptions.js
@@ -53,7 +53,9 @@ export default function FormMappingOptions({
 
 			if (Liferay.FeatureFlags['LPD-20213'] && classNameId !== '0') {
 				openInfoFieldSelector({
+					formItemId: item.itemId,
 					itemType: type.className,
+					segmentsExperienceId: state.segmentsExperienceId,
 					onCancel: resetMapping,
 					onSave: saveMapping,
 				});

--- a/modules/apps/layout/layout-content-page-editor-web/types/src/main/resources/META-INF/resources/page_editor/app/services/FormService.d.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/types/src/main/resources/META-INF/resources/page_editor/app/services/FormService.d.ts
@@ -42,11 +42,13 @@ declare const _default: {
 		groupId?: string | undefined;
 	}): Promise<string[]>;
 	updateFormItemConfig({
+		fields,
 		itemConfig,
 		itemId,
 		onNetworkStatus,
 		segmentsExperienceId,
 	}: {
+		fields: string[];
 		itemConfig: FormLayoutDataItem['config'];
 		itemId: string;
 		onNetworkStatus: OnNetworkStatus;

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -33,6 +33,7 @@ import com.liferay.info.item.provider.InfoItemObjectProvider;
 import com.liferay.info.item.provider.InfoItemPermissionProvider;
 import com.liferay.info.item.provider.InfoItemScopeProvider;
 import com.liferay.info.item.provider.InfoItemStatusProvider;
+import com.liferay.info.item.provider.RelatedInfoItemProvider;
 import com.liferay.info.item.renderer.InfoItemRenderer;
 import com.liferay.info.item.renderer.InfoItemRendererRegistry;
 import com.liferay.info.item.updater.InfoItemFieldValuesUpdater;
@@ -85,6 +86,7 @@ import com.liferay.object.web.internal.info.item.provider.ObjectEntryInfoItemObj
 import com.liferay.object.web.internal.info.item.provider.ObjectEntryInfoItemPermissionProvider;
 import com.liferay.object.web.internal.info.item.provider.ObjectEntryInfoItemScopeProvider;
 import com.liferay.object.web.internal.info.item.provider.ObjectEntryInfoItemStatusProvider;
+import com.liferay.object.web.internal.info.item.provider.ObjectEntryRelatedInfoItemProvider;
 import com.liferay.object.web.internal.info.item.renderer.ObjectEntryRowInfoItemRenderer;
 import com.liferay.object.web.internal.info.item.updater.ObjectEntryInfoItemFieldValuesUpdater;
 import com.liferay.object.web.internal.info.list.renderer.ObjectEntryTableInfoListRenderer;
@@ -539,6 +541,16 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 					"javax.portlet.name", objectDefinition.getPortletId()
 				).put(
 					"mvc.command.name", "/object_entries/edit_object_entry"
+				).build()),
+			_bundleContext.registerService(
+				RelatedInfoItemProvider.class,
+				new ObjectEntryRelatedInfoItemProvider(
+					objectDefinition, _objectDefinitionLocalService,
+					_objectRelationshipLocalService),
+				HashMapDictionaryBuilder.<String, Object>put(
+					"company.id", objectDefinition.getCompanyId()
+				).put(
+					"item.class.name", objectDefinition.getClassName()
 				).build()),
 			_bundleContext.registerService(
 				UserNotificationDefinition.class,

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryRelatedInfoItemProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryRelatedInfoItemProvider.java
@@ -1,0 +1,63 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.web.internal.info.item.provider;
+
+import com.liferay.info.item.provider.RelatedInfoItemProvider;
+import com.liferay.object.constants.ObjectRelationshipConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.petra.function.transform.TransformUtil;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * @author Eudaldo Alonso
+ */
+public class ObjectEntryRelatedInfoItemProvider
+	implements RelatedInfoItemProvider<ObjectEntry> {
+
+	public ObjectEntryRelatedInfoItemProvider(
+		ObjectDefinition objectDefinition,
+		ObjectDefinitionLocalService objectDefinitionLocalService,
+		ObjectRelationshipLocalService objectRelationshipLocalService) {
+
+		_objectDefinition = objectDefinition;
+		_objectDefinitionLocalService = objectDefinitionLocalService;
+		_objectRelationshipLocalService = objectRelationshipLocalService;
+	}
+
+	@Override
+	public List<String> getRelatedItemClassNames() {
+		return TransformUtil.transform(
+			_objectRelationshipLocalService.getObjectRelationships(
+				_objectDefinition.getObjectDefinitionId(),
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY),
+			objectRelationship -> {
+				if (!objectRelationship.isSelf() &&
+					Objects.equals(
+						_objectDefinition.getObjectDefinitionId(),
+						objectRelationship.getObjectDefinitionId1())) {
+
+					return null;
+				}
+
+				ObjectDefinition parentObjectDefinition =
+					_objectDefinitionLocalService.fetchObjectDefinition(
+						objectRelationship.getObjectDefinitionId1());
+
+				return parentObjectDefinition.getClassName();
+			});
+	}
+
+	private final ObjectDefinition _objectDefinition;
+	private final ObjectDefinitionLocalService _objectDefinitionLocalService;
+	private final ObjectRelationshipLocalService
+		_objectRelationshipLocalService;
+
+}


### PR DESCRIPTION
- LPD-23768 Adds new interface to represent relationship between info items
- LPD-23768 Register
- LPD-23768 Adds new resource command to get one to many relationships
- LPD-23768 Add to display context
- LPD-23768 Implements objects RelatedInfoItemProvider
- LPD-23768 Adds tests
- LPD-25327 baseline
- LPD-26916 Send fields in a different param
- LPD-26916 Types
- LPD-26916 Adds tests to validate new behavior, where we can select specific fields
- LPD-26916 Only add selected fields to form container
- LPD-26916 Adds tests to validate when we are adding new fields to form using the modal
- LPD-26916 Implements logic to add new info fields
- LPD-26916 Includes submit button only when we are adding the form for the first time
- LPD-26916 Adds tests to validate when we are deleting fields to form using the modal
- LPD-26916 Removes items when they are not present in the list
- LPD-X wip
