### PR TITLE
LPD-32886 Create new SF rules for Playwright projects without test.properties file

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/TSConfigFileCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/TSConfigFileCheck.java
@@ -1,0 +1,42 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.check;
+
+import com.liferay.petra.string.StringPool;
+
+import java.io.File;
+
+/**
+ * @author Alan Huang
+ */
+public class TSConfigFileCheck extends BaseFileCheck {
+
+	@Override
+	protected String doProcess(
+		String fileName, String absolutePath, String content) {
+
+		if (!absolutePath.contains("/modules/test/playwright/tests/") ||
+			!fileName.endsWith("/config.ts")) {
+
+			return content;
+		}
+
+		int x = absolutePath.lastIndexOf(StringPool.SLASH);
+
+		String playwrightTestDirLocation = absolutePath.substring(0, x);
+
+		File file = new File(playwrightTestDirLocation + "/test.properties");
+
+		if (!file.exists()) {
+			addMessage(
+				fileName,
+				"Missing test.properties in " + playwrightTestDirLocation);
+		}
+
+		return content;
+	}
+
+}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/TSConfigFileCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/TSConfigFileCheck.java
@@ -15,6 +15,11 @@ import java.io.File;
 public class TSConfigFileCheck extends BaseFileCheck {
 
 	@Override
+	public boolean isLiferaySourceCheck() {
+		return true;
+	}
+
+	@Override
 	protected String doProcess(
 		String fileName, String absolutePath, String content) {
 

--- a/modules/util/source-formatter/src/main/resources/sourcechecks.xml
+++ b/modules/util/source-formatter/src/main/resources/sourcechecks.xml
@@ -1681,6 +1681,13 @@
 			<property name="allowTrailingEmptyLines" value="true" />
 			<property name="enabled" value="false" />
 		</check>
+
+		<!-- Liferay Source Checks -->
+
+		<check name="TSConfigFileCheck">
+			<category name="Bug Prevention" />
+			<description name="Finds missing `test.properties` files." />
+		</check>
 	</source-processor>
 	<source-processor name="TXTSourceProcessor">
 		<check name="TXTEmptyLinesCheck">


### PR DESCRIPTION
Hi @sandrodw3 

SF catches 4 issues, can you please fix them? Thanks.
```
java.lang.Exception: Found 4 formatting issues:
1: Missing test.properties in /Users/alan/liferay_code/master/liferay-portal/modules/test/playwright/tests/configuration-admin-web: /Users/alan/liferay_code/master/liferay-portal/modules/test/playwright/tests/configuration-admin-web/config.ts (SourceCheck:TSConfigFileCheck)
2: Missing test.properties in /Users/alan/liferay_code/master/liferay-portal/modules/test/playwright/tests/cookies-banner-web: /Users/alan/liferay_code/master/liferay-portal/modules/test/playwright/tests/cookies-banner-web/config.ts (SourceCheck:TSConfigFileCheck)
3: Missing test.properties in /Users/alan/liferay_code/master/liferay-portal/modules/test/playwright/tests/frontend-js-spa-web: /Users/alan/liferay_code/master/liferay-portal/modules/test/playwright/tests/frontend-js-spa-web/config.ts (SourceCheck:TSConfigFileCheck)
4: Missing test.properties in /Users/alan/liferay_code/master/liferay-portal/modules/test/playwright/tests/portal-workflow-task-web: /Users/alan/liferay_code/master/liferay-portal/modules/test/playwright/tests/portal-workflow-task-web/config.ts (SourceCheck:TSConfigFileCheck)

```