### PR TITLE
LPD-82870 Restoring and expiring versions from versions pane does not provide the right feedback to the user

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/tab_content/index.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/tab_content/index.ts
@@ -97,7 +97,8 @@ export const VERSION_ACTIONS: any = {
 			event: React.MouseEvent<HTMLAnchorElement>,
 			objectEntry: IAssetObjectEntry,
 			loadData: () => {},
-			objectEntryTitle: string
+			objectEntryTitle: string,
+			dataSetId?: string
 		) => {
 			event?.preventDefault();
 
@@ -107,6 +108,7 @@ export const VERSION_ACTIONS: any = {
 					`<strong>${sub(Liferay.Language.get('version-x'), objectEntry.systemProperties.version.number)}</strong>`,
 					Liferay.Util.escapeHTML(objectEntryTitle)
 				),
+				dataSetId,
 				deleteAction: objectEntry.actions.delete,
 				loadData,
 				successMessage: sub(
@@ -126,13 +128,21 @@ export const VERSION_ACTIONS: any = {
 		action: (
 			event: React.MouseEvent<HTMLAnchorElement>,
 			objectEntry: IAssetObjectEntry,
-			refreshData: () => {}
+			refreshData: (responseData: any) => {},
+			objectEntryTitle: string,
+			dataSetId?: string
 		) => {
 			event?.preventDefault();
 
 			executeAsyncItemAction({
 				method: objectEntry.actions.expire.method,
-				refreshData,
+				refreshData: (responseData) => {
+					refreshData?.(responseData);
+
+					Liferay.fire(FDS_EVENT_UPDATE_DISPLAY, {
+						id: dataSetId,
+					});
+				},
 				successMessage: sub(
 					Liferay.Language.get('expire-version-success-message'),
 					`<strong>${sub(Liferay.Language.get('version-x'), objectEntry.systemProperties.version.number)}</strong>`
@@ -193,13 +203,21 @@ export const VERSION_ACTIONS: any = {
 		action: (
 			event: React.MouseEvent<HTMLAnchorElement>,
 			objectEntry: IAssetObjectEntry,
-			refreshData: () => {}
+			refreshData: (responseData: any) => {},
+			objectEntryTitle: string,
+			dataSetId?: string
 		) => {
 			event.preventDefault();
 
 			executeAsyncItemAction({
 				method: objectEntry.actions.restore.method,
-				refreshData,
+				refreshData: (responseData) => {
+					refreshData?.(responseData);
+
+					Liferay.fire(FDS_EVENT_UPDATE_DISPLAY, {
+						id: dataSetId,
+					});
+				},
 				successMessage: sub(
 					Liferay.Language.get('restore-version-success-message'),
 					`<strong>${sub(Liferay.Language.get('version-x'), objectEntry.systemProperties.version.number)}</strong>`

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/actions/confirmAndDeleteEntryAction.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/actions/confirmAndDeleteEntryAction.ts
@@ -3,17 +3,20 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {FDS_EVENT_UPDATE_DISPLAY} from '../../../common/utils/constants';
 import {openCMSModal} from '../../../common/utils/openCMSModal';
 import {executeAsyncItemAction} from '../utils/executeAsyncItemAction';
 
 export default function confirmAndDeleteEntryAction({
 	bodyHTML,
+	dataSetId,
 	deleteAction,
 	loadData,
 	successMessage,
 	title,
 }: {
 	bodyHTML: string;
+	dataSetId?: string;
 	deleteAction: {href: string; method: string};
 	loadData: () => void;
 	successMessage: string;
@@ -36,7 +39,13 @@ export default function confirmAndDeleteEntryAction({
 
 					executeAsyncItemAction({
 						method: deleteAction.method,
-						refreshData: loadData,
+						refreshData: (responseData) => {
+							loadData();
+
+							Liferay.fire(FDS_EVENT_UPDATE_DISPLAY, {
+								id: dataSetId,
+							});
+						},
 						successMessage,
 						url: deleteAction.href,
 					});

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/info_panel/tab_content/VERSION_ACTIONS.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/info_panel/tab_content/VERSION_ACTIONS.test.ts
@@ -1,0 +1,105 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {cleanup} from '@testing-library/react';
+
+import {FDS_EVENT_UPDATE_DISPLAY} from '../../../../src/main/resources/META-INF/resources/js/common/utils/constants';
+import {VERSION_ACTIONS} from '../../../../src/main/resources/META-INF/resources/js/main_view/info_panel/tab_content/index';
+import {executeAsyncItemAction} from '../../../../src/main/resources/META-INF/resources/js/main_view/props_transformer/utils/executeAsyncItemAction';
+import confirmAndDeleteEntryAction from '../../../../src/main/resources/META-INF/resources/js/main_view/props_transformer/actions/confirmAndDeleteEntryAction';
+
+jest.mock('../../../../src/main/resources/META-INF/resources/js/main_view/props_transformer/utils/executeAsyncItemAction');
+jest.mock('../../../../src/main/resources/META-INF/resources/js/main_view/props_transformer/actions/confirmAndDeleteEntryAction');
+
+const mockLiferay = {
+	fire: jest.fn(),
+	Language: {
+		get: jest.fn((key) => key),
+	},
+	Util: {
+		escapeHTML: jest.fn((str) => str),
+	},
+};
+
+(global as any).Liferay = mockLiferay;
+
+describe('VERSION_ACTIONS', () => {
+	afterEach(() => {
+		jest.clearAllMocks();
+		cleanup();
+	});
+
+	const mockObjectEntry = {
+		actions: {
+			delete: {href: '/delete', method: 'DELETE'},
+			expire: {href: '/expire', method: 'PUT'},
+			restore: {href: '/restore', method: 'PUT'},
+		},
+		systemProperties: {
+			version: {number: '1.0'},
+		},
+	};
+
+	const dataSetId = 'test-dataset-id';
+	const refreshData = jest.fn();
+	const event = {preventDefault: jest.fn()} as any;
+
+	it('EXPIRE action fires FDS_EVENT_UPDATE_DISPLAY with dataSetId', async () => {
+		(executeAsyncItemAction as jest.Mock).mockImplementation(({refreshData}) => {
+			refreshData({title: 'Test Asset'});
+			return Promise.resolve();
+		});
+
+		await VERSION_ACTIONS.expire.action(
+			event,
+			mockObjectEntry,
+			refreshData,
+			'Test Title',
+			dataSetId
+		);
+
+		expect(mockLiferay.fire).toHaveBeenCalledWith(FDS_EVENT_UPDATE_DISPLAY, {
+			id: dataSetId,
+		});
+		expect(refreshData).toHaveBeenCalled();
+	});
+
+	it('RESTORE action fires FDS_EVENT_UPDATE_DISPLAY with dataSetId', async () => {
+		(executeAsyncItemAction as jest.Mock).mockImplementation(({refreshData}) => {
+			refreshData({title: 'Test Asset'});
+			return Promise.resolve();
+		});
+
+		await VERSION_ACTIONS.restore.action(
+			event,
+			mockObjectEntry,
+			refreshData,
+			'Test Title',
+			dataSetId
+		);
+
+		expect(mockLiferay.fire).toHaveBeenCalledWith(FDS_EVENT_UPDATE_DISPLAY, {
+			id: dataSetId,
+		});
+		expect(refreshData).toHaveBeenCalled();
+	});
+
+	it('DELETE_VERSION action passes dataSetId to confirmAndDeleteEntryAction', async () => {
+		await VERSION_ACTIONS.delete.action(
+			event,
+			mockObjectEntry,
+			refreshData,
+			'Test Title',
+			dataSetId
+		);
+
+		expect(confirmAndDeleteEntryAction).toHaveBeenCalledWith(
+			expect.objectContaining({
+				dataSetId,
+				loadData: refreshData,
+			})
+		);
+	});
+});


### PR DESCRIPTION
- **LPD-82870 Support dataSetId in confirmAndDeleteEntryAction**
- **LPD-82870 Update fds when version action is completed**
- **LPD-82870 Add unit tests for version actions**
