### PR TITLE
LPD-88532 Update test to match new Collection Applied Filters panel

### DIFF
--- a/modules/test/playwright/tests/layout-content-page-editor-web/fragments/collectionFilterFragment.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/fragments/collectionFilterFragment.spec.ts
@@ -616,21 +616,11 @@ test('Reset collection filter using applied filters', async ({
 
 	await pageEditorPage.selectFragment(collectionAppliedFilterId);
 
-	await expect(
-		page.getByText(
-			'You will see this fragment on the page only after applying a filter.'
-		)
-	).toBeVisible();
-
 	await page.getByLabel('Select', {exact: true}).click();
 
 	await page.getByLabel(ANIMALS_COLLECTION_NAME).check();
 
-	await page
-		.getByText(
-			'You will see this fragment on the page only after applying a filter.'
-		)
-		.click();
+	await page.getByLabel('Select', {exact: true}).click();
 
 	// Check Include Clear Filters Option
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88532

## Failing Test

`layout-content-page-editor-web/fragments/collectionFilterFragment.spec.ts > Reset collection filter using applied filters`

`modules/test/playwright/tests/layout-content-page-editor-web/fragments/collectionFilterFragment.spec.ts`

```
Error: Timed out 15000ms waiting for expect(locator).toBeVisible()
Locator: getByText('You will see this fragment on the page only after applying a filter.')
Expected: visible
Received: <element(s) not found>
```

## Root Cause

Commit `075842f99ed9` ("LPD-77767 convert targetCollection to a new configuration type") removed `CollectionAppliedFiltersGeneralPanel.js` and consolidated the Collection Applied Filters fragment configuration under the standard fragment panel via the new `TargetCollectionDisplayField`. The info text "You will see this fragment on the page only after applying a filter." is no longer rendered, so the test's `expect(...).toBeVisible()` and the click on that same text (used to dismiss the target collection dropdown) both fail against the new UI.

## Fix

Drop the obsolete assertion that waited for the removed info text, and replace the click on that text with a second click on the `Select` trigger to toggle the target collection dropdown closed. The rest of the test scenario (selecting the target collection, enabling Include Clear Filters Option, publishing and exercising the runtime filter behavior) is unchanged and still covers the regression scope.

- `modules/test/playwright/tests/layout-content-page-editor-web/fragments/collectionFilterFragment.spec.ts`