### PR TITLE
LPD-88692 Restore filter-application hint in Applied Filters sidebar

### DIFF
--- a/modules/apps/fragment/fragment-renderer-collection-filter-impl/src/main/resources/com/liferay/fragment/renderer/collection/filter/internal/dependencies/collection-applied-filters-configuration.json
+++ b/modules/apps/fragment/fragment-renderer-collection-filter-impl/src/main/resources/com/liferay/fragment/renderer/collection/filter/internal/dependencies/collection-applied-filters-configuration.json
@@ -8,7 +8,10 @@
 					],
 					"label": "target-collection",
 					"name": "targetCollections",
-					"type": "targetCollectionDisplay"
+					"type": "targetCollectionDisplay",
+					"typeOptions": {
+						"showAppliedFilterHint": true
+					}
 				},
 				{
 					"defaultValue": "false",

--- a/modules/apps/fragment/fragment-service/src/main/resources/com/liferay/fragment/internal/validator/dependencies/configuration-json-schema.json
+++ b/modules/apps/fragment/fragment-service/src/main/resources/com/liferay/fragment/internal/validator/dependencies/configuration-json-schema.json
@@ -494,6 +494,10 @@
 						"enableCompatibleCollections": {
 							"title": "The EnableCompatibleCollections Schema",
 							"type": "boolean"
+						},
+						"showAppliedFilterHint": {
+							"title": "The ShowAppliedFilterHint Schema",
+							"type": "boolean"
 						}
 					},
 					"title": "The Typeoptions Schema",

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment_configuration_fields/TargetCollectionDisplayField.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment_configuration_fields/TargetCollectionDisplayField.js
@@ -22,6 +22,8 @@ import {isLayoutDataItemDeleted} from '../../utils/isLayoutDataItemDeleted';
 export function TargetCollectionDisplayField({field, onValueSelect, value}) {
 	const enableCompatibleCollections =
 		field.typeOptions?.enableCompatibleCollections || false;
+	const showAppliedFilterHint =
+		field.typeOptions?.showAppliedFilterHint || false;
 
 	const [active, setActive] = useState(false);
 	const [filterableCollections, setFilterableCollections] = useState(null);
@@ -142,67 +144,80 @@ export function TargetCollectionDisplayField({field, onValueSelect, value}) {
 	});
 
 	return (
-		<ClayForm.Group className="mt-1">
-			<label htmlFor={inputId}>
-				{field.label || Liferay.Language.get('target-collection')}
-			</label>
-
-			<ClayDropDown
-				active={active}
-				id={inputId}
-				menuElementAttrs={{
-					containerProps: {
-						className:
-							'cadmin page-editor__target-collections-field',
-					},
-				}}
-				onActiveChange={setActive}
-				trigger={
-					<ClayButton
-						aria-label={Liferay.Language.get('select')}
-						className="bg-light font-weight-normal form-control-select text-left w-100"
-						displayType="secondary"
-						size="sm"
-					>
-						{inputValue ? (
-							<span className="text-dark">{inputValue}</span>
-						) : (
-							Liferay.Language.get('select')
-						)}
-					</ClayButton>
-				}
-			>
-				{enableCompatibleCollections &&
-					Object.keys(filterableCollections).length > 1 && (
-						<ClayDropDown.Help className="pt-3 px-3">
-							{Liferay.Language.get(
-								'multiple-selection-must-have-at-least-one-filter-in-common'
-							)}
-						</ClayDropDown.Help>
+		<>
+			{showAppliedFilterHint && (
+				<p
+					aria-live="polite"
+					className="alert alert-info mt-2 text-center"
+				>
+					{Liferay.Language.get(
+						'you-will-see-this-fragment-on-the-page-only-after-applying-a-filter'
 					)}
+				</p>
+			)}
 
-				{items.map((item) => (
-					<label
-						className={classNames('d-flex dropdown-item', {
-							disabled: item.disabled,
-						})}
-						key={item.value}
-						onMouseLeave={() => hoverItem(null)}
-						onMouseOver={() => hoverItem(item.value)}
-					>
-						<ClayCheckbox
-							checked={item.checked}
-							disabled={item.disabled}
-							onChange={item.onChange}
-						/>
+			<ClayForm.Group className="mt-1">
+				<label htmlFor={inputId}>
+					{field.label || Liferay.Language.get('target-collection')}
+				</label>
 
-						<span className="font-weight-normal ml-2">
-							{item.label}
-						</span>
-					</label>
-				))}
-			</ClayDropDown>
-		</ClayForm.Group>
+				<ClayDropDown
+					active={active}
+					id={inputId}
+					menuElementAttrs={{
+						containerProps: {
+							className:
+								'cadmin page-editor__target-collections-field',
+						},
+					}}
+					onActiveChange={setActive}
+					trigger={
+						<ClayButton
+							aria-label={Liferay.Language.get('select')}
+							className="bg-light font-weight-normal form-control-select text-left w-100"
+							displayType="secondary"
+							size="sm"
+						>
+							{inputValue ? (
+								<span className="text-dark">{inputValue}</span>
+							) : (
+								Liferay.Language.get('select')
+							)}
+						</ClayButton>
+					}
+				>
+					{enableCompatibleCollections &&
+						Object.keys(filterableCollections).length > 1 && (
+							<ClayDropDown.Help className="pt-3 px-3">
+								{Liferay.Language.get(
+									'multiple-selection-must-have-at-least-one-filter-in-common'
+								)}
+							</ClayDropDown.Help>
+						)}
+
+					{items.map((item) => (
+						<label
+							className={classNames('d-flex dropdown-item', {
+								disabled: item.disabled,
+							})}
+							key={item.value}
+							onMouseLeave={() => hoverItem(null)}
+							onMouseOver={() => hoverItem(item.value)}
+						>
+							<ClayCheckbox
+								checked={item.checked}
+								disabled={item.disabled}
+								onChange={item.onChange}
+							/>
+
+							<span className="font-weight-normal ml-2">
+								{item.label}
+							</span>
+						</label>
+					))}
+				</ClayDropDown>
+			</ClayForm.Group>
+		</>
 	);
 }
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88692

## Failing Test

`layout-content-page-editor-web/fragments/collectionFilterFragment.spec.ts > Reset collection filter using applied filters`

`modules/test/playwright/tests/layout-content-page-editor-web/fragments/collectionFilterFragment.spec.ts`

```
Error: Timed out 15000ms waiting for expect(locator).toBeVisible()

Locator: getByText('You will see this fragment on the page only after applying a filter.')
Expected: visible
Received: <element(s) not found>
Call log:
  - Expect "toBeVisible" with timeout 15000ms
  - waiting for getByText('You will see this fragment on the page only after applying a filter.')
```

## Root Cause

Commit `075842f99ed98` ("LPD-77767 convert targetCollection to a new configuration type") replaced the custom `CollectionAppliedFiltersGeneralPanel` with a generic JSON-driven configuration backed by `TargetCollectionDisplayField`. The deleted panel rendered the `you-will-see-this-fragment-on-the-page-only-after-applying-a-filter` hint above the dropdown whenever at least one filterable collection existed; the new field never rendered that hint, so the Applied Filters configuration sidebar lost the message.

## Fix

Add a `showAppliedFilterHint` typeOption to `TargetCollectionDisplayField` that, when enabled, renders the same informational paragraph above the dropdown — matching the original panel's behavior. Declare the typeOption in the fragment configuration JSON schema and turn it on for the Applied Filters fragment by setting `showAppliedFilterHint: true` in `collection-applied-filters-configuration.json`. The Collection Filter fragment still uses its own custom panel and is unaffected.

- `modules/apps/fragment/fragment-renderer-collection-filter-impl/src/main/resources/com/liferay/fragment/renderer/collection/filter/internal/dependencies/collection-applied-filters-configuration.json`
- `modules/apps/fragment/fragment-service/src/main/resources/com/liferay/fragment/internal/validator/dependencies/configuration-json-schema.json`
- `modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment_configuration_fields/TargetCollectionDisplayField.js`
