### PR TITLE
LPD-88710 Mock _language and assert language id in import map URL

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/test/java/com/liferay/frontend/js/web/internal/js/importmaps/extender/FrontendJSWebDynamicJSImportMapsContributorTest.java
+++ b/modules/apps/frontend-js/frontend-js-web/src/test/java/com/liferay/frontend/js/web/internal/js/importmaps/extender/FrontendJSWebDynamicJSImportMapsContributorTest.java
@@ -10,6 +10,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.frontend.hashed.files.CachingStrategy;
 import com.liferay.portal.kernel.frontend.hashed.files.HashedFilesRegistry;
+import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
@@ -165,6 +166,9 @@ public class FrontendJSWebDynamicJSImportMapsContributorTest {
 			frontendJSWebDynamicJSImportMapsContributor, "_hashedFilesRegistry",
 			_mockHashedFileRegistry());
 		ReflectionTestUtils.setField(
+			frontendJSWebDynamicJSImportMapsContributor, "_language",
+			_mockLanguage());
+		ReflectionTestUtils.setField(
 			frontendJSWebDynamicJSImportMapsContributor, "_portal",
 			_mockPortal());
 
@@ -245,6 +249,18 @@ public class FrontendJSWebDynamicJSImportMapsContributorTest {
 		return hashedFilesRegistry;
 	}
 
+	private Language _mockLanguage() {
+		Language language = Mockito.mock(Language.class);
+
+		Mockito.when(
+			language.getLanguageId((HttpServletRequest)Mockito.any())
+		).thenReturn(
+			"en_US"
+		);
+
+		return language;
+	}
+
 	private Portal _mockPortal() throws Exception {
 		Portal portal = Mockito.mock(Portal.class);
 
@@ -276,85 +292,91 @@ public class FrontendJSWebDynamicJSImportMapsContributorTest {
 	}
 
 	private static final String[] _RESULTS = {
-		"\"@liferay/language/\": \"/o/js/language/\"",
-		"\"@liferay/language/\": \"/liferay/o/js/language/\"",
-		"\"@liferay/language/\": \"/dxp/o/js/language/\"",
-		"\"@liferay/language/\": \"/liferay/dxp/o/js/language/\"",
-		"\"@liferay/language/\": \"http://cdn.com/o/js/language/\"",
-		"\"@liferay/language/\": \"http://cdn.com/liferay/o/js/language/\"",
-		"\"@liferay/language/\": \"http://cdn.com/dxp/o/js/language/\"",
-		"\"@liferay/language/\": \"http://cdn.com/liferay/dxp/o/js/language/\"",
+		"\"@liferay/language/\": \"/o/js/language/en_US/\"",
+		"\"@liferay/language/\": \"/liferay/o/js/language/en_US/\"",
+		"\"@liferay/language/\": \"/dxp/o/js/language/en_US/\"",
+		"\"@liferay/language/\": \"/liferay/dxp/o/js/language/en_US/\"",
+		"\"@liferay/language/\": \"http://cdn.com/o/js/language/en_US/\"",
 		StringBundler.concat(
-			"\"@liferay/language/\": \"/o/js/language/\", ",
+			"\"@liferay/language/\": ",
+			"\"http://cdn.com/liferay/o/js/language/en_US/\""),
+		"\"@liferay/language/\": \"http://cdn.com/dxp/o/js/language/en_US/\"",
+		StringBundler.concat(
+			"\"@liferay/language/\": ",
+			"\"http://cdn.com/liferay/dxp/o/js/language/en_US/\""),
+		StringBundler.concat(
+			"\"@liferay/language/\": \"/o/js/language/en_US/\", ",
 			"\"/o/frontend-js-web/__liferay__/index.js\": ",
 			"\"/o/frontend-js-web/__liferay__/index.(HASH).js\""),
 		StringBundler.concat(
-			"\"@liferay/language/\": \"/liferay/o/js/language/\", ",
+			"\"@liferay/language/\": \"/liferay/o/js/language/en_US/\", ",
 			"\"/liferay/o/frontend-js-web/__liferay__/index.js\": ",
 			"\"/liferay/o/frontend-js-web/__liferay__/index.(HASH).js\""),
 		StringBundler.concat(
-			"\"@liferay/language/\": \"/dxp/o/js/language/\", ",
+			"\"@liferay/language/\": \"/dxp/o/js/language/en_US/\", ",
 			"\"/dxp/o/frontend-js-web/__liferay__/index.js\": ",
 			"\"/dxp/o/frontend-js-web/__liferay__/index.(HASH).js\""),
 		StringBundler.concat(
-			"\"@liferay/language/\": \"/liferay/dxp/o/js/language/\", ",
+			"\"@liferay/language/\": \"/liferay/dxp/o/js/language/en_US/\", ",
 			"\"/liferay/dxp/o/frontend-js-web/__liferay__/index.js\": ",
 			"\"/liferay/dxp/o/frontend-js-web/__liferay__/index.(HASH).js\""),
 		StringBundler.concat(
-			"\"@liferay/language/\": \"http://cdn.com/o/js/language/\", ",
+			"\"@liferay/language/\": \"http://cdn.com/o/js/language/en_US/\", ",
 			"\"http://cdn.com/o/frontend-js-web/__liferay__/index.js\": ",
 			"\"http://cdn.com/o/frontend-js-web/__liferay__/index.(HASH).js\""),
 		StringBundler.concat(
 			"\"@liferay/language/\": ",
-			"\"http://cdn.com/liferay/o/js/language/\", ",
+			"\"http://cdn.com/liferay/o/js/language/en_US/\", ",
 			"\"http://cdn.com/liferay/o/frontend-js-web/__liferay__/index.",
 			"js\": ",
 			"\"http://cdn.com/liferay/o/frontend-js-web/__liferay__/index.",
 			"(HASH).js\""),
 		StringBundler.concat(
-			"\"@liferay/language/\": \"http://cdn.com/dxp/o/js/language/\", ",
+			"\"@liferay/language/\": ",
+			"\"http://cdn.com/dxp/o/js/language/en_US/\", ",
 			"\"http://cdn.com/dxp/o/frontend-js-web/__liferay__/index.js\": ",
 			"\"http://cdn.com/dxp/o/frontend-js-web/__liferay__/index.(HASH).",
 			"js\""),
 		StringBundler.concat(
 			"\"@liferay/language/\": ",
-			"\"http://cdn.com/liferay/dxp/o/js/language/\", ",
+			"\"http://cdn.com/liferay/dxp/o/js/language/en_US/\", ",
 			"\"http://cdn.com/liferay/dxp/o/frontend-js-web/__liferay__",
 			"/index.js\": ",
 			"\"http://cdn.com/liferay/dxp/o/frontend-js-web/__liferay__",
 			"/index.(HASH).js\""),
 		StringBundler.concat(
-			"\"@liferay/language/\": \"/o/js/language/\", ",
+			"\"@liferay/language/\": \"/o/js/language/en_US/\", ",
 			"\"/o/js/-/frontend-js-web/\": ",
 			"\"/o/js/-/frontend-js-web(HASH)/\""),
 		StringBundler.concat(
-			"\"@liferay/language/\": \"/liferay/o/js/language/\", ",
+			"\"@liferay/language/\": \"/liferay/o/js/language/en_US/\", ",
 			"\"/liferay/o/js/-/frontend-js-web/\": ",
 			"\"/liferay/o/js/-/frontend-js-web(HASH)/\""),
 		StringBundler.concat(
-			"\"@liferay/language/\": \"/dxp/o/js/language/\", ",
+			"\"@liferay/language/\": \"/dxp/o/js/language/en_US/\", ",
 			"\"/dxp/o/js/-/frontend-js-web/\": ",
 			"\"/dxp/o/js/-/frontend-js-web(HASH)/\""),
 		StringBundler.concat(
-			"\"@liferay/language/\": \"/liferay/dxp/o/js/language/\", ",
+			"\"@liferay/language/\": \"/liferay/dxp/o/js/language/en_US/\", ",
 			"\"/liferay/dxp/o/js/-/frontend-js-web/\": ",
 			"\"/liferay/dxp/o/js/-/frontend-js-web(HASH)/\""),
 		StringBundler.concat(
-			"\"@liferay/language/\": \"http://cdn.com/o/js/language/\", ",
+			"\"@liferay/language/\": \"http://cdn.com/o/js/language/en_US/\", ",
 			"\"http://cdn.com/o/js/-/frontend-js-web/\": ",
 			"\"http://cdn.com/o/js/-/frontend-js-web(HASH)/\""),
 		StringBundler.concat(
 			"\"@liferay/language/\": ",
-			"\"http://cdn.com/liferay/o/js/language/\", ",
+			"\"http://cdn.com/liferay/o/js/language/en_US/\", ",
 			"\"http://cdn.com/liferay/o/js/-/frontend-js-web/\": ",
 			"\"http://cdn.com/liferay/o/js/-/frontend-js-web(HASH)/\""),
 		StringBundler.concat(
-			"\"@liferay/language/\": \"http://cdn.com/dxp/o/js/language/\", ",
+			"\"@liferay/language/\": ",
+			"\"http://cdn.com/dxp/o/js/language/en_US/\", ",
 			"\"http://cdn.com/dxp/o/js/-/frontend-js-web/\": ",
 			"\"http://cdn.com/dxp/o/js/-/frontend-js-web(HASH)/\""),
 		StringBundler.concat(
 			"\"@liferay/language/\": ",
-			"\"http://cdn.com/liferay/dxp/o/js/language/\", ",
+			"\"http://cdn.com/liferay/dxp/o/js/language/en_US/\", ",
 			"\"http://cdn.com/liferay/dxp/o/js/-/frontend-js-web/\": ",
 			"\"http://cdn.com/liferay/dxp/o/js/-/frontend-js-web(HASH)/\"")
 	};


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88710

## Failing Test

`com.liferay.frontend.js.web.internal.js.importmaps.extender.FrontendJSWebDynamicJSImportMapsContributorTest`

`modules/apps/frontend-js/frontend-js-web/src/test/java/com/liferay/frontend/js/web/internal/js/importmaps/extender/FrontendJSWebDynamicJSImportMapsContributorTest.java`

```
java.lang.NullPointerException: Cannot invoke "com.liferay.portal.kernel.language.Language.getLanguageId(jakarta.servlet.http.HttpServletRequest)" because "this._language" is null
    at com.liferay.frontend.js.web.internal.js.importmaps.extender.FrontendJSWebDynamicJSImportMapsContributor.writeGlobalImports(FrontendJSWebDynamicJSImportMapsContributor.java:51)
    at com.liferay.frontend.js.web.internal.js.importmaps.extender.FrontendJSWebDynamicJSImportMapsContributorTest.testWriteGlobalImports(FrontendJSWebDynamicJSImportMapsContributorTest.java:177)
```

All 24 parameterized `testWriteGlobalImports` cases failed with the same NPE.

## Root Cause

Commit `2d08e85110a3` ("LPD-83084 Move language id portion to the import map. This allows node-scripts to generate static imports for the label JS files, thus preventing top-level await that still today is not well supported in Safari") added a new `_language` reference to `FrontendJSWebDynamicJSImportMapsContributor` and changed the import map URL contract so it now ends with the language id (e.g. `/o/js/language/en_US/`). The unit test was not updated, so it never set the new field via reflection (NPE at runtime) and its expected URLs no longer match the new shape.

## Fix

Mock the new `_language` reference in the test to return `en_US` for any `HttpServletRequest`, set it via `ReflectionTestUtils.setField` alongside `_hashedFilesRegistry` and `_portal`, and append `en_US/` to every expected URL in `_RESULTS` so the assertions match the new contract. Wrap the four entries that exceeded 80 columns after the change with `StringBundler.concat` to satisfy the source formatter.

- `modules/apps/frontend-js/frontend-js-web/src/test/java/com/liferay/frontend/js/web/internal/js/importmaps/extender/FrontendJSWebDynamicJSImportMapsContributorTest.java`
