### PR TITLE
LPD-XXX Include PhoneNumber attributes in MappingContentUtil

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/util/MappingContentUtil.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/util/MappingContentUtil.java
@@ -11,6 +11,7 @@ import com.liferay.info.field.InfoFieldSetEntry;
 import com.liferay.info.field.type.InfoFieldType;
 import com.liferay.info.field.type.MultiselectInfoFieldType;
 import com.liferay.info.field.type.OptionInfoFieldType;
+import com.liferay.info.field.type.PhoneNumberInfoFieldType;
 import com.liferay.info.field.type.SelectInfoFieldType;
 import com.liferay.info.form.InfoForm;
 import com.liferay.info.item.InfoItemServiceRegistry;
@@ -47,17 +48,7 @@ public class MappingContentUtil {
 		InfoField<?> infoField, Locale locale) {
 
 		return JSONUtil.put(
-			"attributes",
-			() -> {
-				JSONArray optionsJSONArray = _getOptionsJSONArray(
-					infoField, locale);
-
-				if (optionsJSONArray == null) {
-					return null;
-				}
-
-				return JSONUtil.put("options", optionsJSONArray);
-			}
+			"attributes", () -> _getAttributesJSONObject(infoField, locale)
 		).put(
 			"externalKey", infoField.getExternalUniqueId()
 		).put(
@@ -107,6 +98,30 @@ public class MappingContentUtil {
 		return _getMappingFieldsJSONArray(
 			formVariationKey, groupId, false, infoItemServiceRegistry,
 			itemClassName, locale);
+	}
+
+	private static JSONObject _getAttributesJSONObject(
+		InfoField infoField, Locale locale) {
+
+		InfoFieldType infoFieldType = infoField.getInfoFieldType();
+
+		if (infoFieldType instanceof PhoneNumberInfoFieldType) {
+			return JSONUtil.put(
+				"prefix",
+				infoField.getAttribute(PhoneNumberInfoFieldType.PREFIX)
+			).put(
+				"prefixType",
+				infoField.getAttribute(PhoneNumberInfoFieldType.PREFIX_TYPE)
+			);
+		}
+
+		JSONArray optionsJSONArray = _getOptionsJSONArray(infoField, locale);
+
+		if (optionsJSONArray == null) {
+			return null;
+		}
+
+		return JSONUtil.put("options", optionsJSONArray);
 	}
 
 	private static JSONObject _getInfoFieldSetJSONObject(


### PR DESCRIPTION
Includes the PhoneNumber attributes (prefix and prefixType) in MappingContentUtil so they are exposed alongside the existing options attribute.