### PR TITLE
LPD-98182 Dashboard display context review fixes

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -30,7 +30,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
-import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -222,7 +221,9 @@ public abstract class BaseSectionDisplayContext {
 	public Map<String, Object> getBreadcrumbProps() throws PortalException {
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
-		addBreadcrumbItem(jsonArray, false, null, _getLayoutName());
+		addBreadcrumbItem(
+			jsonArray, false, null,
+			SectionDisplayContextUtil.getLayoutName(themeDisplay));
 
 		return HashMapBuilder.<String, Object>put(
 			"breadcrumbItems", jsonArray
@@ -325,16 +326,6 @@ public abstract class BaseSectionDisplayContext {
 		).put(
 			"mimeType", translationInfoItemFieldValuesExporter.getMimeType()
 		);
-	}
-
-	private String _getLayoutName() {
-		Layout layout = themeDisplay.getLayout();
-
-		if (layout == null) {
-			return null;
-		}
-
-		return layout.getName(themeDisplay.getLocale(), true);
 	}
 
 	private JSONArray _getLocalesJSONArray(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextUtil.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
@@ -824,6 +825,16 @@ public class SectionDisplayContextUtil {
 			));
 
 		return fdsActionDropdownItems;
+	}
+
+	public static String getLayoutName(ThemeDisplay themeDisplay) {
+		Layout layout = themeDisplay.getLayout();
+
+		if (layout == null) {
+			return null;
+		}
+
+		return layout.getName(themeDisplay.getLocale(), true);
 	}
 
 	public static Map<String, String> getObjectDefinitionCssClasses() {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewDashboardDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewDashboardDisplayContext.java
@@ -120,7 +120,7 @@ public class ViewDashboardDisplayContext {
 		).put(
 			"candidateAssetLibraries",
 			SectionDisplayContextUtil.getDepotEntriesJSONArray(
-				_httpServletRequest, null)
+				_httpServletRequest)
 		).put(
 			"cmsGroupId", () -> _getCMSGroupId()
 		).put(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewDashboardDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewDashboardDisplayContext.java
@@ -17,7 +17,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
-import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
@@ -112,7 +111,8 @@ public class ViewDashboardDisplayContext {
 					JSONUtil.put(
 						"active", false
 					).put(
-						"label", _getLayoutName()
+						"label",
+						SectionDisplayContextUtil.getLayoutName(_themeDisplay)
 					))
 			).put(
 				"hideSpace", true
@@ -180,16 +180,6 @@ public class ViewDashboardDisplayContext {
 		}
 
 		return null;
-	}
-
-	private String _getLayoutName() {
-		Layout layout = _themeDisplay.getLayout();
-
-		if (layout == null) {
-			return null;
-		}
-
-		return layout.getName(_themeDisplay.getLocale(), true);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewDashboardDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewDashboardDisplayContext.java
@@ -23,7 +23,6 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.site.cms.site.initializer.internal.util.CommentUtil;
@@ -55,20 +54,7 @@ public class ViewDashboardDisplayContext {
 
 	public Map<String, Object> getConstants() {
 		return HashMapBuilder.<String, Object>put(
-			"cmsGroupId",
-			() -> {
-				try {
-					Group group = _groupLocalService.getGroup(
-						_themeDisplay.getCompanyId(), GroupConstants.CMS);
-
-					return group.getGroupId();
-				}
-				catch (PortalException portalException) {
-					_log.error(portalException);
-				}
-
-				return null;
-			}
+			"cmsGroupId", () -> _getCMSGroupId()
 		).put(
 			"ercContentStructures",
 			ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES
@@ -136,22 +122,7 @@ public class ViewDashboardDisplayContext {
 			SectionDisplayContextUtil.getDepotEntriesJSONArray(
 				_httpServletRequest, null)
 		).put(
-			"cmsGroupId",
-			() -> {
-				try {
-					Group group = _groupLocalService.getGroup(
-						_themeDisplay.getCompanyId(), GroupConstants.CMS);
-
-					return GetterUtil.getLong(group.getGroupId());
-				}
-				catch (PortalException portalException) {
-					if (_log.isDebugEnabled()) {
-						_log.debug(portalException);
-					}
-				}
-
-				return null;
-			}
+			"cmsGroupId", () -> _getCMSGroupId()
 		).put(
 			"collaboratorURLs",
 			() -> SectionDisplayContextUtil.getCollaboratorURLs(
@@ -195,6 +166,20 @@ public class ViewDashboardDisplayContext {
 		).put(
 			"redirect", _themeDisplay.getURLCurrent()
 		).build();
+	}
+
+	private Long _getCMSGroupId() {
+		try {
+			Group group = _groupLocalService.getGroup(
+				_themeDisplay.getCompanyId(), GroupConstants.CMS);
+
+			return group.getGroupId();
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+		}
+
+		return null;
 	}
 
 	private String _getLayoutName() {


### PR DESCRIPTION
Review fixes stacked on top of the dashboard display context work in this PR.

https://liferay.atlassian.net/browse/LPD-98182

- Deduplicate the dashboard CMS group ID lookup: `getConstants()` and `_getAdditionalProps()` both computed it, with divergent error handling (`error` vs a guarded `debug`) and a redundant `GetterUtil.getLong`; both now call a single `_getCMSGroupId()` helper.
- Deduplicate the layout name lookup: `_getLayoutName()` was copied in `BaseSectionDisplayContext` and `ViewDashboardDisplayContext`; it now lives in `SectionDisplayContextUtil.getLayoutName(ThemeDisplay)` and is used from both.
- Simplify the dashboard candidate asset libraries lookup: the dashboard called the two-arg `getDepotEntriesJSONArray(request, null)`, whose null root external reference code only diverges from the one-arg overload when the request carries an `INFO_ITEM`; the dashboard has none and wants all `TYPE_SPACE` depots, so it now uses the one-arg overload.

All three commits compile and pass source formatting.
