### PR TITLE
LPD-101437 Frontend preview for testing the delete page version API

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/bnd.bnd
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Admin Site API
 Bundle-SymbolicName: com.liferay.headless.admin.site.api
-Bundle-Version: 26.1.1
+Bundle-Version: 26.2.0
 Export-Package:\
 	com.liferay.headless.admin.site.dto.v1_0,\
 	com.liferay.headless.admin.site.dto.v1_0.util,\

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageSpecificationVersion.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageSpecificationVersion.java
@@ -64,6 +64,53 @@ public class PageSpecificationVersion implements Serializable {
 	}
 
 	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "Block of actions allowed by the user making the request."
+	)
+	@Valid
+	public Map<String, Map<String, String>> getActions() {
+		if (_actionsSupplier != null) {
+			actions = _actionsSupplier.get();
+
+			_actionsSupplier = null;
+		}
+
+		return actions;
+	}
+
+	public void setActions(Map<String, Map<String, String>> actions) {
+		this.actions = actions;
+
+		_actionsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setActions(
+		UnsafeSupplier<Map<String, Map<String, String>>, Exception>
+			actionsUnsafeSupplier) {
+
+		_actionsSupplier = () -> {
+			try {
+				return actionsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "Block of actions allowed by the user making the request."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Map<String, Map<String, String>> actions;
+
+	@JsonIgnore
+	private Supplier<Map<String, Map<String, String>>> _actionsSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
 		description = "The page specification version's creator. It is not returned by default. It can be embedded via nestedFields."
 	)
 	@Valid
@@ -505,6 +552,18 @@ public class PageSpecificationVersion implements Serializable {
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
 			"yyyy-MM-dd'T'HH:mm:ss'Z'");
 
+		Map<String, Map<String, String>> actions = getActions();
+
+		if (actions != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"actions\": ");
+
+			sb.append(_toJSON(actions));
+		}
+
 		Creator creator = getCreator();
 
 		if (creator != null) {
@@ -774,4 +833,4 @@ public class PageSpecificationVersion implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1023824597
+// LIFERAY-REST-BUILDER-HASH:947369518

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/resource/v1_0/PageSpecificationVersionResource.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/resource/v1_0/PageSpecificationVersionResource.java
@@ -44,6 +44,12 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface PageSpecificationVersionResource {
 
+	public void deleteSiteSitePagePageSpecificationVersion(
+			String siteExternalReferenceCode,
+			String sitePageExternalReferenceCode,
+			String pageSpecificationVersionExternalReferenceCode)
+		throws Exception;
+
 	public PageSpecificationVersion getSiteSitePagePageSpecificationVersion(
 			String siteExternalReferenceCode,
 			String sitePageExternalReferenceCode,
@@ -152,4 +158,4 @@ public interface PageSpecificationVersionResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1909812915
+// LIFERAY-REST-BUILDER-HASH:-1497794721

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/resources/com/liferay/headless/admin/site/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/resources/com/liferay/headless/admin/site/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 24.7.0
+version 24.8.0

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/resources/com/liferay/headless/admin/site/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/resources/com/liferay/headless/admin/site/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 9.1.0
+version 9.2.0

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageSpecificationVersion.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageSpecificationVersion.java
@@ -13,6 +13,7 @@ import jakarta.annotation.Generated;
 import java.io.Serializable;
 
 import java.util.Date;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -25,6 +26,28 @@ public class PageSpecificationVersion implements Cloneable, Serializable {
 	public static PageSpecificationVersion toDTO(String json) {
 		return PageSpecificationVersionSerDes.toDTO(json);
 	}
+
+	public Map<String, Map<String, String>> getActions() {
+		return actions;
+	}
+
+	public void setActions(Map<String, Map<String, String>> actions) {
+		this.actions = actions;
+	}
+
+	public void setActions(
+		UnsafeSupplier<Map<String, Map<String, String>>, Exception>
+			actionsUnsafeSupplier) {
+
+		try {
+			actions = actionsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Map<String, Map<String, String>> actions;
 
 	public Creator getCreator() {
 		return creator;
@@ -288,4 +311,4 @@ public class PageSpecificationVersion implements Cloneable, Serializable {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1875221043
+// LIFERAY-REST-BUILDER-HASH:284458619

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/resource/v1_0/PageSpecificationVersionResource.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/resource/v1_0/PageSpecificationVersionResource.java
@@ -33,6 +33,19 @@ public interface PageSpecificationVersionResource {
 		return new Builder();
 	}
 
+	public void deleteSiteSitePagePageSpecificationVersion(
+			String siteExternalReferenceCode,
+			String sitePageExternalReferenceCode,
+			String pageSpecificationVersionExternalReferenceCode)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			deleteSiteSitePagePageSpecificationVersionHttpResponse(
+				String siteExternalReferenceCode,
+				String sitePageExternalReferenceCode,
+				String pageSpecificationVersionExternalReferenceCode)
+		throws Exception;
+
 	public PageSpecificationVersion getSiteSitePagePageSpecificationVersion(
 			String siteExternalReferenceCode,
 			String sitePageExternalReferenceCode,
@@ -166,6 +179,125 @@ public interface PageSpecificationVersionResource {
 
 	public static class PageSpecificationVersionResourceImpl
 		implements PageSpecificationVersionResource {
+
+		public void deleteSiteSitePagePageSpecificationVersion(
+				String siteExternalReferenceCode,
+				String sitePageExternalReferenceCode,
+				String pageSpecificationVersionExternalReferenceCode)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				deleteSiteSitePagePageSpecificationVersionHttpResponse(
+					siteExternalReferenceCode, sitePageExternalReferenceCode,
+					pageSpecificationVersionExternalReferenceCode);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return;
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				deleteSiteSitePagePageSpecificationVersionHttpResponse(
+					String siteExternalReferenceCode,
+					String sitePageExternalReferenceCode,
+					String pageSpecificationVersionExternalReferenceCode)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.DELETE);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/site-pages/{sitePageExternalReferenceCode}/page-specification-versions/{pageSpecificationVersionExternalReferenceCode}");
+
+			httpInvoker.path(
+				"siteExternalReferenceCode", siteExternalReferenceCode);
+			httpInvoker.path(
+				"sitePageExternalReferenceCode", sitePageExternalReferenceCode);
+			httpInvoker.path(
+				"pageSpecificationVersionExternalReferenceCode",
+				pageSpecificationVersionExternalReferenceCode);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
 
 		public PageSpecificationVersion getSiteSitePagePageSpecificationVersion(
 				String siteExternalReferenceCode,
@@ -412,4 +544,4 @@ public interface PageSpecificationVersionResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-91495900
+// LIFERAY-REST-BUILDER-HASH:1883808917

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageSpecificationVersionSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageSpecificationVersionSerDes.java
@@ -54,6 +54,16 @@ public class PageSpecificationVersionSerDes {
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
 			"yyyy-MM-dd'T'HH:mm:ssXX");
 
+		if (pageSpecificationVersion.getActions() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"actions\": ");
+
+			sb.append(_toJSON(pageSpecificationVersion.getActions()));
+		}
+
 		if (pageSpecificationVersion.getCreator() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -199,6 +209,15 @@ public class PageSpecificationVersionSerDes {
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
 			"yyyy-MM-dd'T'HH:mm:ssXX");
 
+		if (pageSpecificationVersion.getActions() == null) {
+			map.put("actions", null);
+		}
+		else {
+			map.put(
+				"actions",
+				String.valueOf(pageSpecificationVersion.getActions()));
+		}
+
 		if (pageSpecificationVersion.getCreator() == null) {
 			map.put("creator", null);
 		}
@@ -300,7 +319,10 @@ public class PageSpecificationVersionSerDes {
 
 		@Override
 		protected boolean parseMaps(String jsonParserFieldName) {
-			if (Objects.equals(jsonParserFieldName, "creator")) {
+			if (Objects.equals(jsonParserFieldName, "actions")) {
+				return true;
+			}
+			else if (Objects.equals(jsonParserFieldName, "creator")) {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "dateCreated")) {
@@ -338,7 +360,13 @@ public class PageSpecificationVersionSerDes {
 			PageSpecificationVersion pageSpecificationVersion,
 			String jsonParserFieldName, Object jsonParserFieldValue) {
 
-			if (Objects.equals(jsonParserFieldName, "creator")) {
+			if (Objects.equals(jsonParserFieldName, "actions")) {
+				if (jsonParserFieldValue != null) {
+					pageSpecificationVersion.setActions(
+						(Map<String, Map<String, String>>)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "creator")) {
 				if (jsonParserFieldValue != null) {
 					pageSpecificationVersion.setCreator(
 						CreatorSerDes.toDTO((String)jsonParserFieldValue));
@@ -477,4 +505,4 @@ public class PageSpecificationVersionSerDes {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:759938507
+// LIFERAY-REST-BUILDER-HASH:460878729

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
@@ -3015,6 +3015,19 @@ components:
             description:
                 A page specification version of a content page.
             properties:
+                actions:
+                    additionalProperties:
+                        additionalProperties:
+                            description:
+                                The action's properties.
+                            type: string
+                        description:
+                            The action's name.
+                        type: object
+                    description:
+                        Block of actions allowed by the user making the request.
+                    readOnly: true
+                    type: object
                 creator:
                     $ref: ../../headless-admin-user/headless-admin-user-impl/rest-openapi.yaml#Creator
                     description:

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
@@ -8742,6 +8742,32 @@ paths:
                                 type: array
             tags: ["PageSpecificationVersion"]
     "/sites/{siteExternalReferenceCode}/site-pages/{sitePageExternalReferenceCode}/page-specification-versions/{pageSpecificationVersionExternalReferenceCode}":
+        delete:
+            description:
+                Deletes a specific page specification version of a site page.
+            operationId: deleteSiteSitePagePageSpecificationVersion
+            parameters:
+                -   in: path
+                    name: siteExternalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: sitePageExternalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: pageSpecificationVersionExternalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+            responses:
+                204:
+                    content:
+                        application/json: {}
+                        application/xml: {}
+            tags: ["PageSpecificationVersion"]
         get:
             description:
                 Retrieves a specific page specification version of a site page.

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageSpecificationVersionDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageSpecificationVersionDTOConverter.java
@@ -34,6 +34,14 @@ public class PageSpecificationVersionDTOConverter
 
 		return new PageSpecificationVersion() {
 			{
+				setActions(
+					() -> {
+						if (dtoConverterContext == null) {
+							return null;
+						}
+
+						return dtoConverterContext.getActions();
+					});
 				setCreator(
 					() -> CreatorUtil.toCreator(
 						layoutContentVersion.getUserId(),

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/DTOConverterContextUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/DTOConverterContextUtil.java
@@ -36,6 +36,19 @@ public class DTOConverterContextUtil {
 	}
 
 	public static DTOConverterContext getDTOConverterContext(
+		AcceptLanguage acceptLanguage, Map<String, Map<String, String>> actions,
+		Map<String, Object> attributesMap,
+		DTOConverterRegistry dtoConverterRegistry,
+		HttpServletRequest httpServletRequest, Object id, UriInfo uriInfo,
+		User user) {
+
+		return new DefaultDTOConverterContext(
+			acceptLanguage.isAcceptAllLanguages(), actions, attributesMap,
+			dtoConverterRegistry, httpServletRequest, id,
+			acceptLanguage.getPreferredLocale(), uriInfo, user);
+	}
+
+	public static DTOConverterContext getDTOConverterContext(
 		AcceptLanguage acceptLanguage, Map<String, Object> attributesMap,
 		DTOConverterRegistry dtoConverterRegistry,
 		HttpServletRequest httpServletRequest, Object id, UriInfo uriInfo,

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BasePageSpecificationVersionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BasePageSpecificationVersionResourceImpl.java
@@ -69,6 +69,61 @@ public abstract class BasePageSpecificationVersionResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
+	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/site-pages/{sitePageExternalReferenceCode}/page-specification-versions/{pageSpecificationVersionExternalReferenceCode}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Deletes a specific page specification version of a site page."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "siteExternalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "sitePageExternalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "pageSpecificationVersionExternalReferenceCode"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(
+				name = "PageSpecificationVersion"
+			)
+		}
+	)
+	@jakarta.ws.rs.DELETE
+	@jakarta.ws.rs.Path(
+		"/sites/{siteExternalReferenceCode}/site-pages/{sitePageExternalReferenceCode}/page-specification-versions/{pageSpecificationVersionExternalReferenceCode}"
+	)
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public void deleteSiteSitePagePageSpecificationVersion(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
+			String siteExternalReferenceCode,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("sitePageExternalReferenceCode")
+			String sitePageExternalReferenceCode,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam(
+				"pageSpecificationVersionExternalReferenceCode"
+			)
+			String pageSpecificationVersionExternalReferenceCode)
+		throws Exception {
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
 	 * curl -X 'GET' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/site-pages/{sitePageExternalReferenceCode}/page-specification-versions/{pageSpecificationVersionExternalReferenceCode}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
@@ -859,4 +914,4 @@ public abstract class BasePageSpecificationVersionResourceImpl
 		LogFactoryUtil.getLog(BasePageSpecificationVersionResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:932884300
+// LIFERAY-REST-BUILDER-HASH:199467619

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageSpecificationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageSpecificationResourceImpl.java
@@ -283,8 +283,7 @@ public class PageSpecificationResourceImpl
 					pageSpecificationVersionExternalReferenceCode)
 		throws Exception {
 
-		FeatureFlagManagerUtil.checkEnabled(
-			contextCompany.getCompanyId(), "LPD-10622");
+		EnabledUtil.checkPageSpecificationVersionEnabled(contextCompany);
 
 		long groupId = GroupUtil.getStagingAwareGroupId(
 			contextCompany.getCompanyId(), siteExternalReferenceCode);

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageSpecificationVersionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageSpecificationVersionResourceImpl.java
@@ -13,18 +13,17 @@ import com.liferay.headless.admin.site.internal.util.SitePageUtil;
 import com.liferay.headless.admin.site.resource.v1_0.PageSpecificationVersionResource;
 import com.liferay.headless.common.spi.util.GroupUtil;
 import com.liferay.layout.content.model.LayoutContentVersion;
+import com.liferay.layout.content.service.LayoutContentVersionLocalService;
 import com.liferay.layout.content.service.LayoutContentVersionService;
-import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 import com.liferay.portal.vulcan.fields.NestedField;
 import com.liferay.portal.vulcan.fields.NestedFieldId;
 import com.liferay.portal.vulcan.pagination.Page;
-
-import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -73,14 +72,15 @@ public class PageSpecificationVersionResourceImpl
 		Layout layout = _getLayout(
 			false, siteExternalReferenceCode, sitePageExternalReferenceCode);
 
-		LayoutContentVersion layoutContentVersion = _getLayoutContentVersion(
-			pageSpecificationVersionExternalReferenceCode,
-			layout.fetchDraftLayout(), siteExternalReferenceCode);
+		Layout draftLayout = layout.fetchDraftLayout();
 
 		return _toPageSpecificationVersion(
-			layoutContentVersion,
-			_getActionsUnsafeFunction(
-				siteExternalReferenceCode, sitePageExternalReferenceCode));
+			_layoutContentVersionLocalService.
+				getLatestApprovedLayoutContentVersionId(draftLayout.getPlid()),
+			_getLayoutContentVersion(
+				pageSpecificationVersionExternalReferenceCode, draftLayout,
+				siteExternalReferenceCode),
+			siteExternalReferenceCode, sitePageExternalReferenceCode);
 	}
 
 	@NestedField(
@@ -101,30 +101,17 @@ public class PageSpecificationVersionResourceImpl
 
 		Layout draftLayout = layout.fetchDraftLayout();
 
-		UnsafeFunction
-			<LayoutContentVersion, Map<String, Map<String, String>>, Exception>
-				unsafeFunction = _getActionsUnsafeFunction(
-					siteExternalReferenceCode, sitePageExternalReferenceCode);
+		long latestApprovedLayoutContentVersionId =
+			_layoutContentVersionLocalService.
+				getLatestApprovedLayoutContentVersionId(draftLayout.getPlid());
 
 		return Page.of(
 			transform(
 				_layoutContentVersionService.getLayoutContentVersions(
 					draftLayout.getPlid()),
 				layoutContentVersion -> _toPageSpecificationVersion(
-					layoutContentVersion, unsafeFunction)));
-	}
-
-	private UnsafeFunction
-		<LayoutContentVersion, Map<String, Map<String, String>>, Exception>
-			_getActionsUnsafeFunction(
-				String siteExternalReferenceCode,
-				String sitePageExternalReferenceCode) {
-
-		return layoutContentVersion ->
-			LayoutContentVersionActionUtil.getActions(
-				contextScopeChecker, layoutContentVersion,
-				_layoutModelResourcePermission, siteExternalReferenceCode,
-				sitePageExternalReferenceCode, contextUriInfo);
+					latestApprovedLayoutContentVersionId, layoutContentVersion,
+					siteExternalReferenceCode, sitePageExternalReferenceCode)));
 	}
 
 	private Layout _getLayout(
@@ -168,16 +155,29 @@ public class PageSpecificationVersionResourceImpl
 	}
 
 	private PageSpecificationVersion _toPageSpecificationVersion(
+			long latestApprovedLayoutContentVersionId,
 			LayoutContentVersion layoutContentVersion,
-			UnsafeFunction
-				<LayoutContentVersion, Map<String, Map<String, String>>,
-				 Exception> unsafeFunction)
+			String siteExternalReferenceCode,
+			String sitePageExternalReferenceCode)
 		throws Exception {
+
+		boolean deletable = false;
+
+		if ((layoutContentVersion.getStatus() !=
+				WorkflowConstants.STATUS_APPROVED) ||
+			(layoutContentVersion.getLayoutContentVersionId() !=
+				latestApprovedLayoutContentVersionId)) {
+
+			deletable = true;
+		}
 
 		return _pageSpecificationVersionDTOConverter.toDTO(
 			new DefaultDTOConverterContext(
 				contextAcceptLanguage.isAcceptAllLanguages(),
-				unsafeFunction.apply(layoutContentVersion),
+				LayoutContentVersionActionUtil.getActions(
+					contextScopeChecker, deletable, layoutContentVersion,
+					_layoutModelResourcePermission, siteExternalReferenceCode,
+					sitePageExternalReferenceCode, contextUriInfo),
 				_dtoConverterRegistry, contextHttpServletRequest,
 				layoutContentVersion.getLayoutContentVersionId(),
 				contextAcceptLanguage.getPreferredLocale(), contextUriInfo,
@@ -187,6 +187,9 @@ public class PageSpecificationVersionResourceImpl
 
 	@Reference
 	private DTOConverterRegistry _dtoConverterRegistry;
+
+	@Reference
+	private LayoutContentVersionLocalService _layoutContentVersionLocalService;
 
 	@Reference
 	private LayoutContentVersionService _layoutContentVersionService;

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageSpecificationVersionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageSpecificationVersionResourceImpl.java
@@ -55,14 +55,7 @@ public class PageSpecificationVersionResourceImpl
 
 		LayoutContentVersion layoutContentVersion = _getLayoutContentVersion(
 			pageSpecificationVersionExternalReferenceCode,
-			siteExternalReferenceCode);
-
-		Layout draftLayout = layout.fetchDraftLayout();
-
-		if (layoutContentVersion.getPlid() != draftLayout.getPlid()) {
-			throw new IllegalArgumentException(
-				"The page specification version must belong to the site page");
-		}
+			layout.fetchDraftLayout(), siteExternalReferenceCode);
 
 		_layoutContentVersionService.deleteLayoutContentVersion(
 			layoutContentVersion.getLayoutContentVersionId());
@@ -82,14 +75,7 @@ public class PageSpecificationVersionResourceImpl
 
 		LayoutContentVersion layoutContentVersion = _getLayoutContentVersion(
 			pageSpecificationVersionExternalReferenceCode,
-			siteExternalReferenceCode);
-
-		Layout draftLayout = layout.fetchDraftLayout();
-
-		if (layoutContentVersion.getPlid() != draftLayout.getPlid()) {
-			throw new IllegalArgumentException(
-				"The page specification version must belong to the site page");
-		}
+			layout.fetchDraftLayout(), siteExternalReferenceCode);
 
 		return _toPageSpecificationVersion(
 			layoutContentVersion,
@@ -161,14 +147,24 @@ public class PageSpecificationVersionResourceImpl
 	}
 
 	private LayoutContentVersion _getLayoutContentVersion(
-			String externalReferenceCode, String siteExternalReferenceCode)
+			String externalReferenceCode, Layout layout,
+			String siteExternalReferenceCode)
 		throws Exception {
 
-		return _layoutContentVersionService.
-			getLayoutContentVersionByExternalReferenceCode(
-				externalReferenceCode,
-				GroupUtil.getStagingAwareGroupId(
-					contextCompany.getCompanyId(), siteExternalReferenceCode));
+		LayoutContentVersion layoutContentVersion =
+			_layoutContentVersionService.
+				getLayoutContentVersionByExternalReferenceCode(
+					externalReferenceCode,
+					GroupUtil.getStagingAwareGroupId(
+						contextCompany.getCompanyId(),
+						siteExternalReferenceCode));
+
+		if (layoutContentVersion.getPlid() != layout.getPlid()) {
+			throw new IllegalArgumentException(
+				"The page specification version must belong to the site page");
+		}
+
+		return layoutContentVersion;
 	}
 
 	private PageSpecificationVersion _toPageSpecificationVersion(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageSpecificationVersionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageSpecificationVersionResourceImpl.java
@@ -8,12 +8,12 @@ package com.liferay.headless.admin.site.internal.resource.v1_0;
 import com.liferay.headless.admin.site.dto.v1_0.PageSpecificationVersion;
 import com.liferay.headless.admin.site.dto.v1_0.SitePage;
 import com.liferay.headless.admin.site.internal.dto.v1_0.util.DTOConverterContextUtil;
+import com.liferay.headless.admin.site.internal.util.EnabledUtil;
 import com.liferay.headless.admin.site.internal.util.SitePageUtil;
 import com.liferay.headless.admin.site.resource.v1_0.PageSpecificationVersionResource;
 import com.liferay.headless.common.spi.util.GroupUtil;
 import com.liferay.layout.content.model.LayoutContentVersion;
 import com.liferay.layout.content.service.LayoutContentVersionService;
-import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
@@ -43,8 +43,7 @@ public class PageSpecificationVersionResourceImpl
 			String pageSpecificationVersionExternalReferenceCode)
 		throws Exception {
 
-		FeatureFlagManagerUtil.checkEnabled(
-			contextCompany.getCompanyId(), "LPD-10622");
+		EnabledUtil.checkPageSpecificationVersionEnabled(contextCompany);
 
 		Layout layout = _getLayout(
 			false, siteExternalReferenceCode, sitePageExternalReferenceCode);
@@ -74,8 +73,7 @@ public class PageSpecificationVersionResourceImpl
 					sitePageExternalReferenceCode)
 		throws Exception {
 
-		FeatureFlagManagerUtil.checkEnabled(
-			contextCompany.getCompanyId(), "LPD-10622");
+		EnabledUtil.checkPageSpecificationVersionEnabled(contextCompany);
 
 		Layout layout = _getLayout(
 			true, siteExternalReferenceCode, sitePageExternalReferenceCode);

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageSpecificationVersionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageSpecificationVersionResourceImpl.java
@@ -7,6 +7,7 @@ package com.liferay.headless.admin.site.internal.resource.v1_0;
 
 import com.liferay.headless.admin.site.dto.v1_0.PageSpecificationVersion;
 import com.liferay.headless.admin.site.dto.v1_0.SitePage;
+import com.liferay.headless.admin.site.internal.dto.v1_0.util.DTOConverterContextUtil;
 import com.liferay.headless.admin.site.internal.resource.v1_0.util.LayoutContentVersionActionUtil;
 import com.liferay.headless.admin.site.internal.util.EnabledUtil;
 import com.liferay.headless.admin.site.internal.util.SitePageUtil;
@@ -20,10 +21,11 @@ import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermi
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
-import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 import com.liferay.portal.vulcan.fields.NestedField;
 import com.liferay.portal.vulcan.fields.NestedFieldId;
 import com.liferay.portal.vulcan.pagination.Page;
+
+import java.util.Collections;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -172,16 +174,16 @@ public class PageSpecificationVersionResourceImpl
 		}
 
 		return _pageSpecificationVersionDTOConverter.toDTO(
-			new DefaultDTOConverterContext(
-				contextAcceptLanguage.isAcceptAllLanguages(),
+			DTOConverterContextUtil.getDTOConverterContext(
+				contextAcceptLanguage,
 				LayoutContentVersionActionUtil.getActions(
 					contextScopeChecker, deletable, layoutContentVersion,
 					_layoutModelResourcePermission, siteExternalReferenceCode,
 					sitePageExternalReferenceCode, contextUriInfo),
-				_dtoConverterRegistry, contextHttpServletRequest,
+				Collections.emptyMap(), _dtoConverterRegistry,
+				contextHttpServletRequest,
 				layoutContentVersion.getLayoutContentVersionId(),
-				contextAcceptLanguage.getPreferredLocale(), contextUriInfo,
-				contextUser),
+				contextUriInfo, contextUser),
 			layoutContentVersion);
 	}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageSpecificationVersionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageSpecificationVersionResourceImpl.java
@@ -7,19 +7,24 @@ package com.liferay.headless.admin.site.internal.resource.v1_0;
 
 import com.liferay.headless.admin.site.dto.v1_0.PageSpecificationVersion;
 import com.liferay.headless.admin.site.dto.v1_0.SitePage;
-import com.liferay.headless.admin.site.internal.dto.v1_0.util.DTOConverterContextUtil;
+import com.liferay.headless.admin.site.internal.resource.v1_0.util.LayoutContentVersionActionUtil;
 import com.liferay.headless.admin.site.internal.util.EnabledUtil;
 import com.liferay.headless.admin.site.internal.util.SitePageUtil;
 import com.liferay.headless.admin.site.resource.v1_0.PageSpecificationVersionResource;
 import com.liferay.headless.common.spi.util.GroupUtil;
 import com.liferay.layout.content.model.LayoutContentVersion;
 import com.liferay.layout.content.service.LayoutContentVersionService;
+import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
+import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 import com.liferay.portal.vulcan.fields.NestedField;
 import com.liferay.portal.vulcan.fields.NestedFieldId;
 import com.liferay.portal.vulcan.pagination.Page;
+
+import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -81,12 +86,15 @@ public class PageSpecificationVersionResourceImpl
 
 		Layout draftLayout = layout.fetchDraftLayout();
 
-		if (layoutContentVersion.getPlid() == draftLayout.getPlid()) {
-			return _toPageSpecificationVersion(layoutContentVersion);
+		if (layoutContentVersion.getPlid() != draftLayout.getPlid()) {
+			throw new IllegalArgumentException(
+				"The page specification version must belong to the site page");
 		}
 
-		throw new IllegalArgumentException(
-			"The page specification version must belong to the site page");
+		return _toPageSpecificationVersion(
+			layoutContentVersion,
+			_getActionsUnsafeFunction(
+				siteExternalReferenceCode, sitePageExternalReferenceCode));
 	}
 
 	@NestedField(
@@ -107,11 +115,30 @@ public class PageSpecificationVersionResourceImpl
 
 		Layout draftLayout = layout.fetchDraftLayout();
 
+		UnsafeFunction
+			<LayoutContentVersion, Map<String, Map<String, String>>, Exception>
+				unsafeFunction = _getActionsUnsafeFunction(
+					siteExternalReferenceCode, sitePageExternalReferenceCode);
+
 		return Page.of(
 			transform(
 				_layoutContentVersionService.getLayoutContentVersions(
 					draftLayout.getPlid()),
-				this::_toPageSpecificationVersion));
+				layoutContentVersion -> _toPageSpecificationVersion(
+					layoutContentVersion, unsafeFunction)));
+	}
+
+	private UnsafeFunction
+		<LayoutContentVersion, Map<String, Map<String, String>>, Exception>
+			_getActionsUnsafeFunction(
+				String siteExternalReferenceCode,
+				String sitePageExternalReferenceCode) {
+
+		return layoutContentVersion ->
+			LayoutContentVersionActionUtil.getActions(
+				contextScopeChecker, layoutContentVersion,
+				_layoutModelResourcePermission, siteExternalReferenceCode,
+				sitePageExternalReferenceCode, contextUriInfo);
 	}
 
 	private Layout _getLayout(
@@ -145,15 +172,20 @@ public class PageSpecificationVersionResourceImpl
 	}
 
 	private PageSpecificationVersion _toPageSpecificationVersion(
-			LayoutContentVersion layoutContentVersion)
+			LayoutContentVersion layoutContentVersion,
+			UnsafeFunction
+				<LayoutContentVersion, Map<String, Map<String, String>>,
+				 Exception> unsafeFunction)
 		throws Exception {
 
 		return _pageSpecificationVersionDTOConverter.toDTO(
-			DTOConverterContextUtil.getDTOConverterContext(
-				contextAcceptLanguage, _dtoConverterRegistry,
-				contextHttpServletRequest,
+			new DefaultDTOConverterContext(
+				contextAcceptLanguage.isAcceptAllLanguages(),
+				unsafeFunction.apply(layoutContentVersion),
+				_dtoConverterRegistry, contextHttpServletRequest,
 				layoutContentVersion.getLayoutContentVersionId(),
-				contextUriInfo, contextUser),
+				contextAcceptLanguage.getPreferredLocale(), contextUriInfo,
+				contextUser),
 			layoutContentVersion);
 	}
 
@@ -162,6 +194,11 @@ public class PageSpecificationVersionResourceImpl
 
 	@Reference
 	private LayoutContentVersionService _layoutContentVersionService;
+
+	@Reference(
+		target = "(model.class.name=com.liferay.portal.kernel.model.Layout)"
+	)
+	private ModelResourcePermission<Layout> _layoutModelResourcePermission;
 
 	@Reference(
 		target = "(component.name=com.liferay.headless.admin.site.internal.dto.v1_0.converter.PageSpecificationVersionDTOConverter)"

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageSpecificationVersionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageSpecificationVersionResourceImpl.java
@@ -37,6 +37,33 @@ public class PageSpecificationVersionResourceImpl
 	extends BasePageSpecificationVersionResourceImpl {
 
 	@Override
+	public void deleteSiteSitePagePageSpecificationVersion(
+			String siteExternalReferenceCode,
+			String sitePageExternalReferenceCode,
+			String pageSpecificationVersionExternalReferenceCode)
+		throws Exception {
+
+		EnabledUtil.checkPageSpecificationVersionEnabled(contextCompany);
+
+		Layout layout = _getLayout(
+			false, siteExternalReferenceCode, sitePageExternalReferenceCode);
+
+		LayoutContentVersion layoutContentVersion = _getLayoutContentVersion(
+			pageSpecificationVersionExternalReferenceCode,
+			siteExternalReferenceCode);
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		if (layoutContentVersion.getPlid() != draftLayout.getPlid()) {
+			throw new IllegalArgumentException(
+				"The page specification version must belong to the site page");
+		}
+
+		_layoutContentVersionService.deleteLayoutContentVersion(
+			layoutContentVersion.getLayoutContentVersionId());
+	}
+
+	@Override
 	public PageSpecificationVersion getSiteSitePagePageSpecificationVersion(
 			String siteExternalReferenceCode,
 			String sitePageExternalReferenceCode,
@@ -49,8 +76,8 @@ public class PageSpecificationVersionResourceImpl
 			false, siteExternalReferenceCode, sitePageExternalReferenceCode);
 
 		LayoutContentVersion layoutContentVersion = _getLayoutContentVersion(
-			siteExternalReferenceCode,
-			pageSpecificationVersionExternalReferenceCode);
+			pageSpecificationVersionExternalReferenceCode,
+			siteExternalReferenceCode);
 
 		Layout draftLayout = layout.fetchDraftLayout();
 
@@ -107,7 +134,7 @@ public class PageSpecificationVersionResourceImpl
 	}
 
 	private LayoutContentVersion _getLayoutContentVersion(
-			String siteExternalReferenceCode, String externalReferenceCode)
+			String externalReferenceCode, String siteExternalReferenceCode)
 		throws Exception {
 
 		return _layoutContentVersionService.

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutContentVersionActionUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutContentVersionActionUtil.java
@@ -1,0 +1,69 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.internal.resource.v1_0.util;
+
+import com.liferay.headless.admin.site.internal.resource.v1_0.PageSpecificationVersionResourceImpl;
+import com.liferay.layout.content.model.LayoutContentVersion;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.vulcan.util.ActionUtil;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Map;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+public class LayoutContentVersionActionUtil {
+
+	public static Map<String, Map<String, String>> getActions(
+		Object contextScopeChecker, LayoutContentVersion layoutContentVersion,
+		ModelResourcePermission<Layout> layoutModelResourcePermission,
+		String siteExternalReferenceCode, String sitePageExternalReferenceCode,
+		UriInfo uriInfo) {
+
+		Map<String, String> templateParameterMap = HashMapBuilder.put(
+			"pageSpecificationVersionExternalReferenceCode",
+			layoutContentVersion.getExternalReferenceCode()
+		).put(
+			"siteExternalReferenceCode", siteExternalReferenceCode
+		).put(
+			"sitePageExternalReferenceCode", sitePageExternalReferenceCode
+		).build();
+
+		return HashMapBuilder.<String, Map<String, String>>put(
+			"delete",
+			_addAction(
+				contextScopeChecker, layoutContentVersion,
+				layoutModelResourcePermission,
+				"deleteSiteSitePagePageSpecificationVersion",
+				templateParameterMap, uriInfo)
+		).put(
+			"get",
+			_addAction(
+				contextScopeChecker, layoutContentVersion,
+				layoutModelResourcePermission,
+				"getSiteSitePagePageSpecificationVersion", templateParameterMap,
+				uriInfo)
+		).build();
+	}
+
+	private static Map<String, String> _addAction(
+		Object contextScopeChecker, LayoutContentVersion layoutContentVersion,
+		ModelResourcePermission<Layout> layoutModelResourcePermission,
+		String methodName, Map<String, String> templateParameterMap,
+		UriInfo uriInfo) {
+
+		return ActionUtil.addAction(
+			ActionKeys.UPDATE, PageSpecificationVersionResourceImpl.class,
+			layoutContentVersion.getPlid(), methodName, contextScopeChecker,
+			layoutModelResourcePermission, templateParameterMap, uriInfo);
+	}
+
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutContentVersionActionUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutContentVersionActionUtil.java
@@ -23,7 +23,8 @@ import java.util.Map;
 public class LayoutContentVersionActionUtil {
 
 	public static Map<String, Map<String, String>> getActions(
-		Object contextScopeChecker, LayoutContentVersion layoutContentVersion,
+		Object contextScopeChecker, boolean deletable,
+		LayoutContentVersion layoutContentVersion,
 		ModelResourcePermission<Layout> layoutModelResourcePermission,
 		String siteExternalReferenceCode, String sitePageExternalReferenceCode,
 		UriInfo uriInfo) {
@@ -39,11 +40,17 @@ public class LayoutContentVersionActionUtil {
 
 		return HashMapBuilder.<String, Map<String, String>>put(
 			"delete",
-			_addAction(
-				contextScopeChecker, layoutContentVersion,
-				layoutModelResourcePermission,
-				"deleteSiteSitePagePageSpecificationVersion",
-				templateParameterMap, uriInfo)
+			() -> {
+				if (!deletable) {
+					return null;
+				}
+
+				return _addAction(
+					contextScopeChecker, layoutContentVersion,
+					layoutModelResourcePermission,
+					"deleteSiteSitePagePageSpecificationVersion",
+					templateParameterMap, uriInfo);
+			}
 		).put(
 			"get",
 			_addAction(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/util/EnabledUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/util/EnabledUtil.java
@@ -50,4 +50,9 @@ public class EnabledUtil {
 		}
 	}
 
+	public static void checkPageSpecificationVersionEnabled(Company company) {
+		FeatureFlagManagerUtil.checkEnabled(
+			company.getCompanyId(), "LPD-10622");
+	}
+
 }

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BasePageSpecificationVersionResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BasePageSpecificationVersionResourceTestCase.java
@@ -196,6 +196,61 @@ public abstract class BasePageSpecificationVersionResourceTestCase {
 	}
 
 	@Test
+	public void testDeleteSiteSitePagePageSpecificationVersion()
+		throws Exception {
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		PageSpecificationVersion pageSpecificationVersion =
+			testDeleteSiteSitePagePageSpecificationVersion_addPageSpecificationVersion();
+
+		assertHttpResponseStatusCode(
+			204,
+			pageSpecificationVersionResource.
+				deleteSiteSitePagePageSpecificationVersionHttpResponse(
+					testDeleteSiteSitePagePageSpecificationVersion_getSiteExternalReferenceCode(),
+					testDeleteSiteSitePagePageSpecificationVersion_getSitePageExternalReferenceCode(),
+					pageSpecificationVersion.getExternalReferenceCode()));
+
+		assertHttpResponseStatusCode(
+			404,
+			pageSpecificationVersionResource.
+				getSiteSitePagePageSpecificationVersionHttpResponse(
+					testDeleteSiteSitePagePageSpecificationVersion_getSiteExternalReferenceCode(),
+					testDeleteSiteSitePagePageSpecificationVersion_getSitePageExternalReferenceCode(),
+					pageSpecificationVersion.getExternalReferenceCode()));
+		assertHttpResponseStatusCode(
+			404,
+			pageSpecificationVersionResource.
+				getSiteSitePagePageSpecificationVersionHttpResponse(
+					testDeleteSiteSitePagePageSpecificationVersion_getSiteExternalReferenceCode(),
+					testDeleteSiteSitePagePageSpecificationVersion_getSitePageExternalReferenceCode(),
+					"-"));
+	}
+
+	protected PageSpecificationVersion
+			testDeleteSiteSitePagePageSpecificationVersion_addPageSpecificationVersion()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String
+			testDeleteSiteSitePagePageSpecificationVersion_getSiteExternalReferenceCode()
+		throws Exception {
+
+		return testGroup.getExternalReferenceCode();
+	}
+
+	protected String
+			testDeleteSiteSitePagePageSpecificationVersion_getSitePageExternalReferenceCode()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
 	public void testGetSiteSitePagePageSpecificationVersion() throws Exception {
 		PageSpecificationVersion postPageSpecificationVersion =
 			testGetSiteSitePagePageSpecificationVersion_addPageSpecificationVersion();
@@ -471,6 +526,14 @@ public abstract class BasePageSpecificationVersionResourceTestCase {
 		for (String additionalAssertFieldName :
 				getAdditionalAssertFieldNames()) {
 
+			if (Objects.equals("actions", additionalAssertFieldName)) {
+				if (pageSpecificationVersion.getActions() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("creator", additionalAssertFieldName)) {
 				if (pageSpecificationVersion.getCreator() == null) {
 					valid = false;
@@ -655,6 +718,17 @@ public abstract class BasePageSpecificationVersionResourceTestCase {
 
 		for (String additionalAssertFieldName :
 				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("actions", additionalAssertFieldName)) {
+				if (!equals(
+						(Map)pageSpecificationVersion1.getActions(),
+						(Map)pageSpecificationVersion2.getActions())) {
+
+					return false;
+				}
+
+				continue;
+			}
 
 			if (Objects.equals("creator", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(
@@ -868,6 +942,11 @@ public abstract class BasePageSpecificationVersionResourceTestCase {
 		sb.append(" ");
 		sb.append(operator);
 		sb.append(" ");
+
+		if (entityFieldName.equals("actions")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
 
 		if (entityFieldName.equals("creator")) {
 			throw new IllegalArgumentException(
@@ -1359,4 +1438,4 @@ public abstract class BasePageSpecificationVersionResourceTestCase {
 		PageSpecificationVersionResource _pageSpecificationVersionResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1979383916
+// LIFERAY-REST-BUILDER-HASH:1799742455

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageSpecificationVersionResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageSpecificationVersionResourceTest.java
@@ -14,6 +14,7 @@ import com.liferay.layout.content.model.LayoutContentVersion;
 import com.liferay.layout.content.provider.LayoutContentVersionDataProvider;
 import com.liferay.layout.content.service.LayoutContentVersionLocalService;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.User;
@@ -35,6 +36,8 @@ import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -90,6 +93,7 @@ public class PageSpecificationVersionResourceTest
 	public void testGetSiteSitePagePageSpecificationVersion() throws Exception {
 		super.testGetSiteSitePagePageSpecificationVersion();
 
+		_testGetSiteSitePagePageSpecificationVersionActions();
 		_testGetSiteSitePagePageSpecificationVersionMismatchedSitePage();
 		_testGetSiteSitePagePageSpecificationVersionPageSpecificationNestedField();
 	}
@@ -241,6 +245,19 @@ public class PageSpecificationVersionResourceTest
 			pageSpecificationVersion);
 	}
 
+	private void _assertActionHref(
+		Map<String, Map<String, String>> actions, String content,
+		String... keys) {
+
+		for (String key : keys) {
+			Map<String, String> action = actions.get(key);
+
+			String href = action.get("href");
+
+			Assert.assertTrue(key, href.contains(content));
+		}
+	}
+
 	private PageSpecificationVersionResource
 			_getPageSpecificationVersionResource()
 		throws Exception {
@@ -258,6 +275,74 @@ public class PageSpecificationVersionResourceTest
 		).parameters(
 			"nestedFields", "pageSpecification"
 		).build();
+	}
+
+	private void _testGetSiteSitePagePageSpecificationVersionActions()
+		throws Exception {
+
+		PageSpecificationVersion firstPageSpecificationVersion =
+			_addPageSpecificationVersion();
+
+		firstPageSpecificationVersion =
+			pageSpecificationVersionResource.
+				getSiteSitePagePageSpecificationVersion(
+					testGroup.getExternalReferenceCode(),
+					_testGroupLayout.getExternalReferenceCode(),
+					firstPageSpecificationVersion.getExternalReferenceCode());
+
+		Map<String, Map<String, String>> firstActions =
+			firstPageSpecificationVersion.getActions();
+
+		Assert.assertNull(firstActions.get("delete"));
+
+		_assertActionHref(
+			firstActions,
+			StringBundler.concat(
+				"/sites/", testGroup.getExternalReferenceCode(), "/site-pages/",
+				_testGroupLayout.getExternalReferenceCode(),
+				"/page-specification-versions/",
+				firstPageSpecificationVersion.getExternalReferenceCode()),
+			"get");
+
+		PageSpecificationVersion secondPageSpecificationVersion =
+			_addPageSpecificationVersion();
+
+		firstPageSpecificationVersion =
+			pageSpecificationVersionResource.
+				getSiteSitePagePageSpecificationVersion(
+					testGroup.getExternalReferenceCode(),
+					_testGroupLayout.getExternalReferenceCode(),
+					firstPageSpecificationVersion.getExternalReferenceCode());
+
+		_assertActionHref(
+			firstPageSpecificationVersion.getActions(),
+			StringBundler.concat(
+				"/sites/", testGroup.getExternalReferenceCode(), "/site-pages/",
+				_testGroupLayout.getExternalReferenceCode(),
+				"/page-specification-versions/",
+				firstPageSpecificationVersion.getExternalReferenceCode()),
+			"delete", "get");
+
+		secondPageSpecificationVersion =
+			pageSpecificationVersionResource.
+				getSiteSitePagePageSpecificationVersion(
+					testGroup.getExternalReferenceCode(),
+					_testGroupLayout.getExternalReferenceCode(),
+					secondPageSpecificationVersion.getExternalReferenceCode());
+
+		Map<String, Map<String, String>> secondActions =
+			secondPageSpecificationVersion.getActions();
+
+		Assert.assertNull(secondActions.get("delete"));
+
+		_assertActionHref(
+			secondActions,
+			StringBundler.concat(
+				"/sites/", testGroup.getExternalReferenceCode(), "/site-pages/",
+				_testGroupLayout.getExternalReferenceCode(),
+				"/page-specification-versions/",
+				secondPageSpecificationVersion.getExternalReferenceCode()),
+			"get");
 	}
 
 	private void _testGetSiteSitePagePageSpecificationVersionMismatchedSitePage()

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageSpecificationVersionResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageSpecificationVersionResourceTest.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -77,6 +78,15 @@ public class PageSpecificationVersionResourceTest
 
 	@Override
 	@Test
+	@TestInfo("LPD-90029")
+	public void testDeleteSiteSitePagePageSpecificationVersion()
+		throws Exception {
+
+		super.testDeleteSiteSitePagePageSpecificationVersion();
+	}
+
+	@Override
+	@Test
 	public void testGetSiteSitePagePageSpecificationVersion() throws Exception {
 		super.testGetSiteSitePagePageSpecificationVersion();
 
@@ -95,6 +105,22 @@ public class PageSpecificationVersionResourceTest
 	@Override
 	protected String[] getAdditionalAssertFieldNames() {
 		return new String[] {"externalReferenceCode", "name"};
+	}
+
+	@Override
+	protected PageSpecificationVersion
+			testDeleteSiteSitePagePageSpecificationVersion_addPageSpecificationVersion()
+		throws Exception {
+
+		return _addPageSpecificationVersion(WorkflowConstants.STATUS_DRAFT);
+	}
+
+	@Override
+	protected String
+			testDeleteSiteSitePagePageSpecificationVersion_getSitePageExternalReferenceCode()
+		throws Exception {
+
+		return _testGroupLayout.getExternalReferenceCode();
 	}
 
 	@Override
@@ -145,9 +171,7 @@ public class PageSpecificationVersionResourceTest
 	private PageSpecificationVersion _addPageSpecificationVersion()
 		throws Exception {
 
-		return _addPageSpecificationVersion(
-			RandomTestUtil.randomString(), testGroup, _testGroupLayout,
-			RandomTestUtil.randomString());
+		return _addPageSpecificationVersion(WorkflowConstants.STATUS_APPROVED);
 	}
 
 	private PageSpecificationVersion _addPageSpecificationVersion(
@@ -157,12 +181,21 @@ public class PageSpecificationVersionResourceTest
 
 		return _addPageSpecificationVersion(
 			pageSpecificationVersion.getExternalReferenceCode(), group, layout,
-			pageSpecificationVersion.getName());
+			pageSpecificationVersion.getName(),
+			WorkflowConstants.STATUS_APPROVED);
+	}
+
+	private PageSpecificationVersion _addPageSpecificationVersion(int status)
+		throws Exception {
+
+		return _addPageSpecificationVersion(
+			RandomTestUtil.randomString(), testGroup, _testGroupLayout,
+			RandomTestUtil.randomString(), status);
 	}
 
 	private PageSpecificationVersion _addPageSpecificationVersion(
 			String externalReferenceCode, Group group, Layout layout,
-			String name)
+			String name, int status)
 		throws Exception {
 
 		Layout draftLayout = layout.fetchDraftLayout();
@@ -177,7 +210,7 @@ public class PageSpecificationVersionResourceTest
 				HashMapBuilder.put(
 					LocaleUtil.getSiteDefault(), name
 				).build(),
-				draftLayout.getPlid(), WorkflowConstants.STATUS_APPROVED);
+				draftLayout.getPlid(), status);
 
 		if (Validator.isNotNull(externalReferenceCode)) {
 			Assert.assertEquals(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageSpecificationVersionResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageSpecificationVersionResourceTest.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
@@ -101,22 +102,7 @@ public class PageSpecificationVersionResourceTest
 			testGetSiteSitePagePageSpecificationVersion_addPageSpecificationVersion()
 		throws Exception {
 
-		Layout draftLayout = _testGroupLayout.fetchDraftLayout();
-
-		LayoutContentVersion layoutContentVersion =
-			_layoutContentVersionLocalService.addLayoutContentVersion(
-				null, TestPropsValues.getUserId(),
-				_layoutContentVersionDataProvider.getLayoutContentVersionData(
-					draftLayout,
-					ServiceContextTestUtil.getServiceContext(
-						testGroup.getGroupId())),
-				null, draftLayout.getPlid(), WorkflowConstants.STATUS_APPROVED);
-
-		return pageSpecificationVersionResource.
-			getSiteSitePagePageSpecificationVersion(
-				testGroup.getExternalReferenceCode(),
-				_testGroupLayout.getExternalReferenceCode(),
-				layoutContentVersion.getExternalReferenceCode());
+		return _addPageSpecificationVersion();
 	}
 
 	@Override
@@ -156,32 +142,46 @@ public class PageSpecificationVersionResourceTest
 		return _testGroupLayout.getExternalReferenceCode();
 	}
 
+	private PageSpecificationVersion _addPageSpecificationVersion()
+		throws Exception {
+
+		return _addPageSpecificationVersion(
+			RandomTestUtil.randomString(), testGroup, _testGroupLayout,
+			RandomTestUtil.randomString());
+	}
+
 	private PageSpecificationVersion _addPageSpecificationVersion(
 			Group group, Layout layout,
 			PageSpecificationVersion pageSpecificationVersion)
+		throws Exception {
+
+		return _addPageSpecificationVersion(
+			pageSpecificationVersion.getExternalReferenceCode(), group, layout,
+			pageSpecificationVersion.getName());
+	}
+
+	private PageSpecificationVersion _addPageSpecificationVersion(
+			String externalReferenceCode, Group group, Layout layout,
+			String name)
 		throws Exception {
 
 		Layout draftLayout = layout.fetchDraftLayout();
 
 		LayoutContentVersion layoutContentVersion =
 			_layoutContentVersionLocalService.addLayoutContentVersion(
-				pageSpecificationVersion.getExternalReferenceCode(),
-				TestPropsValues.getUserId(),
+				externalReferenceCode, TestPropsValues.getUserId(),
 				_layoutContentVersionDataProvider.getLayoutContentVersionData(
 					draftLayout,
 					ServiceContextTestUtil.getServiceContext(
 						group.getGroupId())),
 				HashMapBuilder.put(
-					LocaleUtil.getSiteDefault(),
-					pageSpecificationVersion.getName()
+					LocaleUtil.getSiteDefault(), name
 				).build(),
 				draftLayout.getPlid(), WorkflowConstants.STATUS_APPROVED);
 
-		if (Validator.isNotNull(
-				pageSpecificationVersion.getExternalReferenceCode())) {
-
+		if (Validator.isNotNull(externalReferenceCode)) {
 			Assert.assertEquals(
-				pageSpecificationVersion.getExternalReferenceCode(),
+				externalReferenceCode,
 				layoutContentVersion.getExternalReferenceCode());
 		}
 

--- a/modules/apps/layout/layout-content-api/bnd.bnd
+++ b/modules/apps/layout/layout-content-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Layout Content API
 Bundle-SymbolicName: com.liferay.layout.content.api
-Bundle-Version: 1.1.1
+Bundle-Version: 1.2.0
 Export-Package:\
 	com.liferay.layout.content.constants,\
 	com.liferay.layout.content.creator,\

--- a/modules/apps/layout/layout-content-api/src/main/java/com/liferay/layout/content/service/LayoutContentVersionLocalService.java
+++ b/modules/apps/layout/layout-content-api/src/main/java/com/liferay/layout/content/service/LayoutContentVersionLocalService.java
@@ -219,6 +219,9 @@ public interface LayoutContentVersionLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public IndexableActionableDynamicQuery getIndexableActionableDynamicQuery();
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public long getLatestApprovedLayoutContentVersionId(long plid);
+
 	/**
 	 * Returns the layout content version with the primary key.
 	 *
@@ -297,4 +300,4 @@ public interface LayoutContentVersionLocalService
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1668532652
+// LIFERAY-SERVICE-BUILDER-HASH:1672056227

--- a/modules/apps/layout/layout-content-api/src/main/java/com/liferay/layout/content/service/LayoutContentVersionLocalServiceUtil.java
+++ b/modules/apps/layout/layout-content-api/src/main/java/com/liferay/layout/content/service/LayoutContentVersionLocalServiceUtil.java
@@ -250,6 +250,10 @@ public class LayoutContentVersionLocalServiceUtil {
 		return getService().getIndexableActionableDynamicQuery();
 	}
 
+	public static long getLatestApprovedLayoutContentVersionId(long plid) {
+		return getService().getLatestApprovedLayoutContentVersionId(plid);
+	}
+
 	/**
 	 * Returns the layout content version with the primary key.
 	 *
@@ -357,4 +361,4 @@ public class LayoutContentVersionLocalServiceUtil {
 			LayoutContentVersionLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1311579954
+// LIFERAY-SERVICE-BUILDER-HASH:59137004

--- a/modules/apps/layout/layout-content-api/src/main/java/com/liferay/layout/content/service/LayoutContentVersionLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-content-api/src/main/java/com/liferay/layout/content/service/LayoutContentVersionLocalServiceWrapper.java
@@ -289,6 +289,12 @@ public class LayoutContentVersionLocalServiceWrapper
 			getIndexableActionableDynamicQuery();
 	}
 
+	@Override
+	public long getLatestApprovedLayoutContentVersionId(long plid) {
+		return _layoutContentVersionLocalService.
+			getLatestApprovedLayoutContentVersionId(plid);
+	}
+
 	/**
 	 * Returns the layout content version with the primary key.
 	 *
@@ -427,4 +433,4 @@ public class LayoutContentVersionLocalServiceWrapper
 	private LayoutContentVersionLocalService _layoutContentVersionLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1534139706
+// LIFERAY-SERVICE-BUILDER-HASH:-643647227

--- a/modules/apps/layout/layout-content-api/src/main/resources/com/liferay/layout/content/service/packageinfo
+++ b/modules/apps/layout/layout-content-api/src/main/resources/com/liferay/layout/content/service/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/layout/layout-content-service/src/main/java/com/liferay/layout/content/service/impl/LayoutContentVersionLocalServiceImpl.java
+++ b/modules/apps/layout/layout-content-service/src/main/java/com/liferay/layout/content/service/impl/LayoutContentVersionLocalServiceImpl.java
@@ -160,24 +160,30 @@ public class LayoutContentVersionLocalServiceImpl
 		_validateLayout(
 			_layoutLocalService.getLayout(layoutContentVersion.getPlid()));
 
-		if (layoutContentVersion.getStatus() ==
-				WorkflowConstants.STATUS_APPROVED) {
+		if ((layoutContentVersion.getStatus() ==
+				WorkflowConstants.STATUS_APPROVED) &&
+			(layoutContentVersion.getLayoutContentVersionId() ==
+				getLatestApprovedLayoutContentVersionId(
+					layoutContentVersion.getPlid()))) {
 
-			LayoutContentVersion latestApprovedLayoutContentVersion =
-				layoutContentVersionPersistence.fetchByP_S_First(
-					layoutContentVersion.getPlid(),
-					WorkflowConstants.STATUS_APPROVED,
-					LayoutContentVersionVersionComparator.getInstance(false));
-
-			if (layoutContentVersion.getLayoutContentVersionId() ==
-					latestApprovedLayoutContentVersion.
-						getLayoutContentVersionId()) {
-
-				throw new RequiredLayoutContentVersionException();
-			}
+			throw new RequiredLayoutContentVersionException();
 		}
 
 		return layoutContentVersionPersistence.remove(layoutContentVersionId);
+	}
+
+	@Override
+	public long getLatestApprovedLayoutContentVersionId(long plid) {
+		LayoutContentVersion latestApprovedLayoutContentVersion =
+			layoutContentVersionPersistence.fetchByP_S_First(
+				plid, WorkflowConstants.STATUS_APPROVED,
+				LayoutContentVersionVersionComparator.getInstance(false));
+
+		if (latestApprovedLayoutContentVersion == null) {
+			return 0;
+		}
+
+		return latestApprovedLayoutContentVersion.getLayoutContentVersionId();
 	}
 
 	@Override

--- a/modules/apps/layout/layout-content-web/package.json
+++ b/modules/apps/layout/layout-content-web/package.json
@@ -2,11 +2,13 @@
 	"dependencies": {
 		"@clayui/button": "^3.165.0",
 		"@clayui/core": "^3.165.0",
+		"@clayui/drop-down": "^3.165.0",
 		"@clayui/empty-state": "^3.165.0",
 		"@clayui/icon": "^3.165.0",
 		"@clayui/label": "^3.165.0",
 		"@clayui/list": "^3.165.0",
 		"@clayui/loading-indicator": "^3.165.0",
+		"@clayui/modal": "^3.165.0",
 		"@clayui/sticker": "^3.165.0",
 		"@clayui/toolbar": "^3.165.0",
 		"@liferay/layout-js-components-web": "*",

--- a/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/js/components/DeleteVersionModal.tsx
+++ b/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/js/components/DeleteVersionModal.tsx
@@ -1,0 +1,48 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayButton from '@clayui/button';
+import ClayModal, {useModal} from '@clayui/modal';
+import React from 'react';
+
+interface Props {
+	onClose: () => void;
+	onConfirm: () => void;
+}
+
+export default function DeleteVersionModal({onClose, onConfirm}: Props) {
+	const {observer, onOpenChange} = useModal({onClose});
+
+	return (
+		<ClayModal observer={observer} size="sm" status="warning">
+			<ClayModal.Header>
+				{Liferay.Language.get('delete-version')}
+			</ClayModal.Header>
+
+			<ClayModal.Body>
+				{Liferay.Language.get(
+					'deleting-a-version-is-an-action-impossible-to-revert'
+				)}
+			</ClayModal.Body>
+
+			<ClayModal.Footer
+				last={
+					<ClayButton.Group spaced>
+						<ClayButton
+							displayType="secondary"
+							onClick={() => onOpenChange(false)}
+						>
+							{Liferay.Language.get('cancel')}
+						</ClayButton>
+
+						<ClayButton displayType="danger" onClick={onConfirm}>
+							{Liferay.Language.get('delete')}
+						</ClayButton>
+					</ClayButton.Group>
+				}
+			/>
+		</ClayModal>
+	);
+}

--- a/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/js/components/VersionHistory.tsx
+++ b/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/js/components/VersionHistory.tsx
@@ -9,11 +9,13 @@ import {
 	useMediaQuery,
 } from '@liferay/layout-js-components-web';
 import {openToast} from 'frontend-js-components-web';
-import React, {useEffect, useState} from 'react';
+import {sub} from 'frontend-js-web';
+import React, {useCallback, useEffect, useState} from 'react';
 
 import {Config, initializeConfig} from '../config';
 import PageVersionService from '../services/PageVersionService';
 import {PageVersion} from '../types/PageVersion';
+import DeleteVersionModal from './DeleteVersionModal';
 import ResponsivePanel from './ResponsivePanel';
 import Toolbar from './Toolbar';
 import VersionList from './VersionList';
@@ -31,6 +33,9 @@ export default function VersionHistory({config}: Props) {
 	const [search, setSearch] = useState('');
 
 	const [versions, setVersions] = useState<PageVersion[] | null>(null);
+	const [versionToDelete, setVersionToDelete] = useState<PageVersion | null>(
+		null
+	);
 
 	const isScreenLarge = useMediaQuery(LARGE_MEDIA_QUERY);
 
@@ -38,29 +43,54 @@ export default function VersionHistory({config}: Props) {
 		hideProductMenuIfPresent({onHide: () => setIsPanelOpen(true)});
 	}, []);
 
+	const loadVersions = useCallback(async (signal?: AbortSignal) => {
+		const {data, error} = await PageVersionService.getPageVersions(signal);
+
+		if (signal?.aborted) {
+			return;
+		}
+
+		if (error) {
+			openToast({message: error, type: 'danger'});
+		}
+
+		setVersions(data?.items ?? []);
+	}, []);
+
 	useEffect(() => {
 		const controller = new AbortController();
 
-		const loadVersions = async () => {
-			const {data, error} = await PageVersionService.getPageVersions(
-				controller.signal
-			);
-
-			if (controller.signal.aborted) {
-				return;
-			}
-
-			if (error) {
-				openToast({message: error, type: 'danger'});
-			}
-
-			setVersions(data?.items ?? []);
-		};
-
-		loadVersions();
+		loadVersions(controller.signal);
 
 		return () => controller.abort();
-	}, []);
+	}, [loadVersions]);
+
+	const handleConfirmDelete = async () => {
+		if (!versionToDelete?.actions?.delete) {
+			return;
+		}
+
+		const {error} = await PageVersionService.deletePageVersion(
+			versionToDelete.actions.delete.href
+		);
+
+		setVersionToDelete(null);
+
+		if (error) {
+			openToast({message: error, type: 'danger'});
+
+			return;
+		}
+
+		openToast({
+			message: sub(Liferay.Language.get('x-was-deleted-successfully'), [
+				versionToDelete.name,
+			]),
+			type: 'success',
+		});
+
+		loadVersions();
+	};
 
 	const keywords = search.trim().toLowerCase();
 
@@ -86,6 +116,7 @@ export default function VersionHistory({config}: Props) {
 								? config.layout
 								: undefined
 						}
+						onDelete={setVersionToDelete}
 						searching={Boolean(keywords)}
 						versions={versions.filter(({creator, name}) =>
 							matches(name, creator?.name)
@@ -99,6 +130,13 @@ export default function VersionHistory({config}: Props) {
 					/>
 				)}
 			</ResponsivePanel>
+
+			{versionToDelete ? (
+				<DeleteVersionModal
+					onClose={() => setVersionToDelete(null)}
+					onConfirm={handleConfirmDelete}
+				/>
+			) : null}
 		</>
 	);
 }

--- a/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/js/components/VersionList.tsx
+++ b/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/js/components/VersionList.tsx
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {ClayButtonWithIcon} from '@clayui/button';
+import {ClayDropDownWithItems} from '@clayui/drop-down';
 import ClayEmptyState from '@clayui/empty-state';
 import ClayIcon from '@clayui/icon';
 import ClayLabel from '@clayui/label';
@@ -38,10 +40,12 @@ type Row = {
 
 export default function VersionList({
 	layout,
+	onDelete,
 	searching,
 	versions,
 }: {
 	layout?: Layout;
+	onDelete?: (version: PageVersion) => void;
 	searching: boolean;
 	versions: PageVersion[];
 }) {
@@ -169,6 +173,39 @@ export default function VersionList({
 								</ClayLabel>
 							</ClayList.ItemText>
 						</ClayList.ItemField>
+
+						{version?.actions?.delete ? (
+							<ClayList.ItemField className="px-2">
+								<ClayDropDownWithItems
+									items={[
+										{
+											label: Liferay.Language.get(
+												'delete-version'
+											),
+											onClick: (event) => {
+												event.stopPropagation();
+
+												onDelete?.(version);
+											},
+											symbolLeft: 'trash',
+										},
+									]}
+									trigger={
+										<ClayButtonWithIcon
+											aria-label={Liferay.Language.get(
+												'show-options'
+											)}
+											displayType="unstyled"
+											onClick={(event) =>
+												event.stopPropagation()
+											}
+											small
+											symbol="ellipsis-v"
+										/>
+									}
+								/>
+							</ClayList.ItemField>
+						) : null}
 					</ClayList.Item>
 				);
 			})}

--- a/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/js/services/ApiHelper.ts
+++ b/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/js/services/ApiHelper.ts
@@ -34,6 +34,13 @@ async function handleRequest<T>(
 			};
 		}
 
+		if (response.status === 204) {
+			return {
+				data: null as unknown as T,
+				error: null,
+			};
+		}
+
 		return {
 			data: await response.json(),
 			error: null,
@@ -45,6 +52,20 @@ async function handleRequest<T>(
 			error: (error as Error).message || UNEXPECTED_ERROR_MESSAGE,
 		};
 	}
+}
+
+async function del<T>(url: string, signal?: AbortSignal) {
+	return handleRequest<T>(() =>
+		fetch(url, {
+			headers: new Headers({
+				'Accept': 'application/json',
+				'Accept-Language': Liferay.ThemeDisplay.getBCP47LanguageId(),
+				'Content-Type': 'application/json',
+			}),
+			method: 'DELETE',
+			signal,
+		})
+	);
 }
 
 async function get<T>(url: string, signal?: AbortSignal) {
@@ -61,4 +82,4 @@ async function get<T>(url: string, signal?: AbortSignal) {
 	);
 }
 
-export default {get};
+export default {del, get};

--- a/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/js/services/PageVersionService.ts
+++ b/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/js/services/PageVersionService.ts
@@ -11,6 +11,10 @@ type PageVersionResponse = Omit<PageVersion, 'status'> & {
 	status: Capitalize<Status>;
 };
 
+async function deletePageVersion(url: string) {
+	return ApiHelper.del<void>(url);
+}
+
 async function getPageVersions(signal?: AbortSignal) {
 	const {data, error} = await ApiHelper.get<{items: PageVersionResponse[]}>(
 		config.pageSpecificationVersionsURL,
@@ -28,4 +32,4 @@ async function getPageVersions(signal?: AbortSignal) {
 	};
 }
 
-export default {getPageVersions};
+export default {deletePageVersion, getPageVersions};

--- a/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/js/types/PageVersion.ts
+++ b/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/js/types/PageVersion.ts
@@ -5,7 +5,13 @@
 
 export type Status = 'approved' | 'draft';
 
+export type Action = {
+	href: string;
+	method: string;
+};
+
 export type PageVersion = {
+	actions?: Record<string, Action>;
 	creator?: {
 		externalReferenceCode?: string;
 		image?: string;

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/servlet/test/MCPServerPromptTest.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/servlet/test/MCPServerPromptTest.java
@@ -164,7 +164,6 @@ public class MCPServerPromptTest {
 		String name = RandomTestUtil.randomString();
 		String prompt = RandomTestUtil.randomString();
 
-
 		_testAddMCPServerPromptObjectEntryWithoutRequiredField(
 			description, identifier, name, null);
 

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/internal/comment/test/MBDiscussionPermissionImplTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/internal/comment/test/MBDiscussionPermissionImplTest.java
@@ -362,18 +362,6 @@ public class MBDiscussionPermissionImplTest {
 			});
 	}
 
-	private long _addComment(User user) throws Exception {
-		IdentityServiceContextFunction serviceContextFunction =
-			new IdentityServiceContextFunction(
-				ServiceContextTestUtil.getServiceContext(
-					_group, user.getUserId()));
-
-		return _commentManager.addComment(
-			user.getUserId(), _group.getGroupId(),
-			DLFileEntryConstants.getClassName(), _fileEntry.getFileEntryId(),
-			StringUtil.randomString(), serviceContextFunction);
-	}
-
 	private long _addCMPProjectComment(User user) throws Exception {
 		CMPTestUtil.getOrAddGroup(MBDiscussionPermissionImplTest.class);
 
@@ -393,6 +381,18 @@ public class MBDiscussionPermissionImplTest {
 			new IdentityServiceContextFunction(
 				ServiceContextTestUtil.getServiceContext(
 					objectEntry.getGroupId(), user.getUserId())));
+	}
+
+	private long _addComment(User user) throws Exception {
+		IdentityServiceContextFunction serviceContextFunction =
+			new IdentityServiceContextFunction(
+				ServiceContextTestUtil.getServiceContext(
+					_group, user.getUserId()));
+
+		return _commentManager.addComment(
+			user.getUserId(), _group.getGroupId(),
+			DLFileEntryConstants.getClassName(), _fileEntry.getFileEntryId(),
+			StringUtil.randomString(), serviceContextFunction);
 	}
 
 	private void _withAlwaysEditableByOwnerEnabled(

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it.
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel.
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed.
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version?
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert.
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone.
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=حذف مجموعة أ
 deleting-a-site-is-an-action-impossible-to-revert=حذف موقع هو إجراء يستحيل التراجع عنه. سوف تتم إزالته جميع المحتوى ولن يكون من الممكن استرداده.
 deleting-a-style-book-is-an-action-impossible-to-revert=حذف سجل الأنماط هو إجراء يستحيل التراجع عنه. سوف تتم إزالة جميع رموز سجلات الأنماط والقيم ولن يكون من الممكن استردادها. احذر من التأثير الخطير على شكل الموقع وإحساسه.
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=حذف طريقة العرض للمستخدم هو إجراء لا يمكن التراجع عنه.
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=حذف المثيل هو إجراء يستحيل التراجع عنه.
 deleting-an-object-definition-also-removes-its-data-records=يؤدي حذف تعريف كائن إلى حذف إدخالات الكائن الخاصة به أيضًا. هذا الإجراء نهائي ولا يمكن التراجع عنه.
 deleting-an-object-folder-will-move-its-object-definitions=حذف مجلد الكائن سوف يزيل تعريفات الكائن إلى مجلد كائنات "غير مصنفة". هذا الإجراء دائم ولا يمكن التراجع عنه.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=L'acció de suprimir u
 deleting-a-site-is-an-action-impossible-to-revert=L'acció de suprimir un lloc web no es pot revertir. Se suprimirà tot el contingut i no es podrà recuperar.
 deleting-a-style-book-is-an-action-impossible-to-revert=L'acció de suprimir un llibre d'estils no es pot revertir. Se suprimiran tots els testimonis i valors del llibre d'estils i no es podrà recuperar. Compte amb l'impacte greu que pot tenir en l'aspecte i el funcionament del lloc web.
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Suprimir una vista d'usuari és una acció que no es pot revertir.
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=L'acció de suprimir una instància no es pot revertir.
 deleting-an-object-definition-also-removes-its-data-records=En suprimir una definició d'objecte, també se suprimeixen les seves entrades d'objecte. Aquesta acció és permanent i no es pot desfer.
 deleting-an-object-folder-will-move-its-object-definitions=Si suprimiu una carpeta d'objecte, les seves definicions d'objecte es mouran a la carpeta d'objecte "No categoritzat". Aquesta acció és permanent i no es pot desfer.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Das Löschen eines Fra
 deleting-a-site-is-an-action-impossible-to-revert=Das Löschen einer Site ist eine Aktion, die nicht rückgängig gemacht werden kann. Alle Inhalte werden entfernt und können nicht wiederhergestellt werden.
 deleting-a-style-book-is-an-action-impossible-to-revert=Das Löschen eines Style Books ist eine Aktion, die nicht rückgängig gemacht werden kann. Alle Style Book-Token und -Werte werden entfernt und können nicht wiederhergestellt werden. Achten Sie auf die kritischen Auswirkungen auf das Erscheinungsbild der Site.
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Das Löschen einer Benutzeransicht ist eine Aktion, die nicht rückgängig gemacht werden kann.
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Das Löschen einer Instanz ist eine Aktion, die nicht rückgängig gemacht werden kann.
 deleting-an-object-definition-also-removes-its-data-records=Wenn Sie eine Objektdefinition löschen, werden auch die zugehörigen Objekteinträge entfernt. Diese Aktion ist dauerhaft und kann nicht rückgängig gemacht werden.
 deleting-an-object-folder-will-move-its-object-definitions=Wenn Sie einen Objektordner löschen, werden seine Objektdefinitionen in den Objektordner "Nicht kategorisiert" verschoben. Diese Aktion ist dauerhaft und kann nicht rückgängig gemacht werden.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_AT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_AT.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Das Löschen eines Fra
 deleting-a-site-is-an-action-impossible-to-revert=Das Löschen einer Site ist eine Aktion, die nicht rückgängig gemacht werden kann. Alle Inhalte werden entfernt und können nicht wiederhergestellt werden.
 deleting-a-style-book-is-an-action-impossible-to-revert=Das Löschen eines Style Books ist eine Aktion, die nicht rückgängig gemacht werden kann. Alle Style Book-Token und -Werte werden entfernt und können nicht wiederhergestellt werden. Achten Sie auf die kritischen Auswirkungen auf das Erscheinungsbild der Site.
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Das Löschen einer Benutzeransicht ist eine Aktion, die nicht rückgängig gemacht werden kann.
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Das Löschen einer Instanz ist eine Aktion, die nicht rückgängig gemacht werden kann.
 deleting-an-object-definition-also-removes-its-data-records=Wenn Sie eine Objektdefinition löschen, werden auch die zugehörigen Objekteinträge entfernt. Diese Aktion ist dauerhaft und kann nicht rückgängig gemacht werden.
 deleting-an-object-folder-will-move-its-object-definitions=Wenn Sie einen Objektordner löschen, werden seine Objektdefinitionen in den Objektordner "Nicht kategorisiert" verschoben. Diese Aktion ist dauerhaft und kann nicht rückgängig gemacht werden.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_CH.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Das Löschen eines Fra
 deleting-a-site-is-an-action-impossible-to-revert=Das Löschen einer Site ist eine Aktion, die nicht rückgängig gemacht werden kann. Alle Inhalte werden entfernt und können nicht wiederhergestellt werden.
 deleting-a-style-book-is-an-action-impossible-to-revert=Das Löschen eines Style Books ist eine Aktion, die nicht rückgängig gemacht werden kann. Alle Style Book-Token und -Werte werden entfernt und können nicht wiederhergestellt werden. Achten Sie auf die kritischen Auswirkungen auf das Erscheinungsbild der Site.
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Das Löschen einer Benutzeransicht ist eine Aktion, die nicht rückgängig gemacht werden kann.
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Das Löschen einer Instanz ist eine Aktion, die nicht rückgängig gemacht werden kann.
 deleting-an-object-definition-also-removes-its-data-records=Wenn Sie eine Objektdefinition löschen, werden auch die zugehörigen Objekteinträge entfernt. Diese Aktion ist dauerhaft und kann nicht rückgängig gemacht werden.
 deleting-an-object-folder-will-move-its-object-definitions=Wenn Sie einen Objektordner löschen, werden seine Objektdefinitionen in den Objektordner "Nicht kategorisiert" verschoben. Diese Aktion ist dauerhaft und kann nicht rückgängig gemacht werden.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it.
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel.
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed.
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version?
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert.
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone.
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_CA.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_IE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_IE.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=La eliminación de un 
 deleting-a-site-is-an-action-impossible-to-revert=La eliminación de un sitio es irreversible. Se quitará todo el contenido y no podrá recuperarlo.
 deleting-a-style-book-is-an-action-impossible-to-revert=La eliminación de un libro de estilo es irreversible. Se quitarán todos los tokens y valores del libro de estilo y no podrá recuperarlo. Compruebe si tendrá un impacto crítico en la apariencia del sitio.
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=La acción de eliminar la visualización de un usuario no se puede revertir.
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Si elimina una instancia, no podrá recuperarla.
 deleting-an-object-definition-also-removes-its-data-records=Al eliminar la definición de un objeto, también se quitarán las entradas del objeto. Esta acción es permanente y no se puede deshacer.
 deleting-an-object-folder-will-move-its-object-definitions=Al eliminar una carpeta de objeto, moverá sus definiciones de objeto a la carpeta de objeto "Sin categorizar". Esta acción es permanente y no se puede deshacer.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=La eliminación de un 
 deleting-a-site-is-an-action-impossible-to-revert=La eliminación de un sitio es irreversible. Se quitará todo el contenido y no podrá recuperarlo.
 deleting-a-style-book-is-an-action-impossible-to-revert=La eliminación de un libro de estilo es irreversible. Se quitarán todos los tokens y valores del libro de estilo y no podrá recuperarlo. Compruebe si tendrá un impacto crítico en la apariencia del sitio.
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=La acción de eliminar la visualización de un usuario no se puede revertir.
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Si elimina una instancia, no podrá recuperarla.
 deleting-an-object-definition-also-removes-its-data-records=Al eliminar la definición de un objeto, también se quitarán las entradas del objeto. Esta acción es permanente y no se puede deshacer.
 deleting-an-object-folder-will-move-its-object-definitions=Al eliminar una carpeta de objeto, moverá sus definiciones de objeto a la carpeta de objeto "Sin categorizar". Esta acción es permanente y no se puede deshacer.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=La eliminación de un 
 deleting-a-site-is-an-action-impossible-to-revert=La eliminación de un sitio es irreversible. Se quitará todo el contenido y no podrá recuperarlo.
 deleting-a-style-book-is-an-action-impossible-to-revert=La eliminación de un libro de estilo es irreversible. Se quitarán todos los tokens y valores del libro de estilo y no podrá recuperarlo. Compruebe si tendrá un impacto crítico en la apariencia del sitio.
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=La acción de eliminar la visualización de un usuario no se puede revertir.
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Si elimina una instancia, no podrá recuperarla.
 deleting-an-object-definition-also-removes-its-data-records=Al eliminar la definición de un objeto, también se quitarán las entradas del objeto. Esta acción es permanente y no se puede deshacer.
 deleting-an-object-folder-will-move-its-object-definitions=Al eliminar una carpeta de objeto, moverá sus definiciones de objeto a la carpeta de objeto "Sin categorizar". Esta acción es permanente y no se puede deshacer.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=La eliminación de un 
 deleting-a-site-is-an-action-impossible-to-revert=La eliminación de un sitio es irreversible. Se quitará todo el contenido y no podrá recuperarlo.
 deleting-a-style-book-is-an-action-impossible-to-revert=La eliminación de un libro de estilo es irreversible. Se quitarán todos los tokens y valores del libro de estilo y no podrá recuperarlo. Compruebe si tendrá un impacto crítico en la apariencia del sitio.
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=La acción de eliminar la visualización de un usuario no se puede revertir.
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Si elimina una instancia, no podrá recuperarla.
 deleting-an-object-definition-also-removes-its-data-records=Al eliminar la definición de un objeto, también se quitarán las entradas del objeto. Esta acción es permanente y no se puede deshacer.
 deleting-an-object-folder-will-move-its-object-definitions=Al eliminar una carpeta de objeto, moverá sus definiciones de objeto a la carpeta de objeto "Sin categorizar". Esta acción es permanente y no se puede deshacer.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Gune bat ezabatzea ezin da leheneratu. Eduki guztia ezabatu egingo da eta ezin izango da berreskuratu.
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Fragmenttijoukon poist
 deleting-a-site-is-an-action-impossible-to-revert=Sivuston poistaminen on toiminto, jonka kumoaminen ei ole mahdollista. Kaikki sisältö poistetaan, eikä sitä voi palauttaa.
 deleting-a-style-book-is-an-action-impossible-to-revert=Tyylikirjan poistaminen on toiminto, jonka kumoaminen ei ole mahdollista. Kaikki tyylikirjan tunnukset ja arvot poistetaan, eikä niitä voi palauttaa. Tarkkaile merkittävää vaikutusta sivuston ulkoasuun ja tuntumaan.
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Käyttäjänäkymän poistamista ei voi kumota.
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Instanssin poistaminen on toiminto, jonka kumoaminen ei ole mahdollista.
 deleting-an-object-definition-also-removes-its-data-records=Objektimäärityksen poistaminen poistaa myös sen objektimerkinnät. Tämä toiminto on pysyvä, eikä sitä voi kumota.
 deleting-an-object-folder-will-move-its-object-definitions=Objektikansion poistaminen siirtää sen objektimääritelmät Luokittelemattomat-objektikansioon. Toiminto on pysyvä, eikä sitä voi kumota.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Supprimer un ensemble 
 deleting-a-site-is-an-action-impossible-to-revert=Supprimer un site est une action impossible à annuler. Tout le contenu sera supprimé et il ne sera pas possible de le récupérer.
 deleting-a-style-book-is-an-action-impossible-to-revert=Supprimer un livre de styles est une action impossible à annuler. Tous les jetons et valeurs du livre de styles seront supprimés et il ne sera pas possible de les récupérer. Méfiez-vous de l'impact critique sur l'apparence du site.
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=La suppression d'une vue utilisateur est une action irréversible.
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=La suppression d'une instance est une action impossible à annuler.
 deleting-an-object-definition-also-removes-its-data-records=La suppression d'une définition d'objet supprime également ses entrées d'objet. Cette action est permanente et ne peut pas être annulée.
 deleting-an-object-folder-will-move-its-object-definitions=La suppression d'un dossier d'objets déplacera ses définitions d'objets vers le dossier d'objets « Non catégorisé ». Cette action est permanente et ne peut pas être annulée.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_BE.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Supprimer un ensemble 
 deleting-a-site-is-an-action-impossible-to-revert=Supprimer un site est une action impossible à annuler. Tout le contenu sera supprimé et il ne sera pas possible de le récupérer.
 deleting-a-style-book-is-an-action-impossible-to-revert=Supprimer un livre de styles est une action impossible à annuler. Tous les jetons et valeurs du livre de styles seront supprimés et il ne sera pas possible de les récupérer. Méfiez-vous de l'impact critique sur l'apparence du site.
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=La suppression d'une vue utilisateur est une action irréversible.
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=La suppression d'une instance est une action impossible à annuler.
 deleting-an-object-definition-also-removes-its-data-records=La suppression d'une définition d'objet supprime également ses entrées d'objet. Cette action est permanente et ne peut pas être annulée.
 deleting-an-object-folder-will-move-its-object-definitions=La suppression d'un dossier d'objets déplacera ses définitions d'objets vers le dossier d'objets « Non catégorisé ». Cette action est permanente et ne peut pas être annulée.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CH.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Supprimer un ensemble 
 deleting-a-site-is-an-action-impossible-to-revert=Supprimer un site est une action impossible à annuler. Tout le contenu sera supprimé et il ne sera pas possible de le récupérer.
 deleting-a-style-book-is-an-action-impossible-to-revert=Supprimer un livre de styles est une action impossible à annuler. Tous les jetons et valeurs du livre de styles seront supprimés et il ne sera pas possible de les récupérer. Méfiez-vous de l'impact critique sur l'apparence du site.
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=La suppression d'une vue utilisateur est une action irréversible.
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=La suppression d'une instance est une action impossible à annuler.
 deleting-an-object-definition-also-removes-its-data-records=La suppression d'une définition d'objet supprime également ses entrées d'objet. Cette action est permanente et ne peut pas être annulée.
 deleting-an-object-folder-will-move-its-object-definitions=La suppression d'un dossier d'objets déplacera ses définitions d'objets vers le dossier d'objets « Non catégorisé ». Cette action est permanente et ne peut pas être annulée.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Eliminar un conxunto d
 deleting-a-site-is-an-action-impossible-to-revert=Eliminar un sitio é unha acción imposible de reverter. Eliminarase todo o contido e non será posible recuperalo.
 deleting-a-style-book-is-an-action-impossible-to-revert=Eliminar un libro de estilo é unha acción imposible de reverter. Eliminaranse todos os tokens e valores do libro de estilo e non será posible recuperalo. Coidado cun impacto crítico no aspecto do sitio.
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Eliminar unha definición de obxecto tamén elimina as entradas do seu obxecto. Esta acción é permanente e non se pode desfacer.
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr_BA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr_BA.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Egy töredékkészlet 
 deleting-a-site-is-an-action-impossible-to-revert=Egy webhely törlési műveletét lehetetlen visszafordítani. Az egész tartalom eltávolításra kerül, és nem lehet visszaállítani.
 deleting-a-style-book-is-an-action-impossible-to-revert=Egy stíluskönyv törlési műveletét lehetetlen visszafordítani. A stíluskönyv összes tokenje eltávolításra kerül, és nem lehet visszaállítani. Gondoljon arra, hogy jelentős hatással van a webhely megjelenésére és hangulatára.
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=A felhasználói nézet törlése olyan művelet, amely nem fordítható vissza.
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Egy példány törlési műveletét lehetetlen visszafordítani.
 deleting-an-object-definition-also-removes-its-data-records=Egy objektumdefiníció törlése az objektumbejegyzéseket is eltávolítja. A művelet végleges, és nem vonható vissza.
 deleting-an-object-folder-will-move-its-object-definitions=Egy objektummappa törlése az objektumdefinícióit a "Kategorizálatlan" objektummappába helyezi át. Ez a művelet végleges, és nem vonható vissza.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
@@ -6491,6 +6491,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it_CH.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=フラグメントセ�
 deleting-a-site-is-an-action-impossible-to-revert=サイトの削除操作は取り消し不可能です。全コンテンツが削除され、復元不可能になります。
 deleting-a-style-book-is-an-action-impossible-to-revert=スタイルブックの削除操作は取り消し不可能です。全スタイルブックのトークンが削除され、復元不可能になります。サイトの外観に重大な影響を及ぼすため、注意してください。
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=ユーザービューの削除は取り消し不可能な操作です。
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=インスタンスの削除は取り消し不可能な操作です。
 deleting-an-object-definition-also-removes-its-data-records=オブジェクトの定義を削除すると、そのオブジェクトエントリーも削除されます。この操作は恒久的なものであり、取り消せません。
 deleting-an-object-folder-will-move-its-object-definitions=オブジェクトフォルダー義を削除すると、そのオブジェクト定義が "カテゴリ未設定" オブジェクトフォルダーに移動されます。この操作は恒久的なものであり、取り消せません。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it.
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert.
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone.
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=프래그먼트 세트
 deleting-a-site-is-an-action-impossible-to-revert=사이트 삭제는 되돌릴 수 없는 작업입니다. 모든 콘텐츠가 삭제되며 복구할 수 없습니다.
 deleting-a-style-book-is-an-action-impossible-to-revert=스타일북 삭제는 되돌릴 수 없는 작업입니다. 모든 스타일북 토큰과 값이 제거되며 복구할 수 없습니다. 사이트의 모양과 느낌에 중요한 영향을 미치므로 주의하십시오.
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=컬렉션 삭제는 되돌릴 수 없는 작업입니다.
 deleting-an-object-definition-also-removes-its-data-records=객체 정의를 삭제하면 해당 객체 항목도 제거됩니다. 이 작업은 영구적이며 취소할 수 없습니다.
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=ການລຶບ fra
 deleting-a-site-is-an-action-impossible-to-revert=ການລຶບເວັບໄຊແມ່ນການກະທຳທີ່ບໍ່ສາມາດຍົກເລີກໄດ້. ເນື້ອຫາທັງໝົດຈະຖືກລຶບອອກ ແລະ ຈະບໍ່ສາມາດກູ້ຄືນໄດ້.
 deleting-a-style-book-is-an-action-impossible-to-revert=ການລຶບ Style Book ແມ່ນການກະທຳທີ່ບໍ່ສາມາດຍົກເລີກໄດ້. Style Book token ແລະ ຄ່າທັງໝົດຈະຖືກລຶບອອກ ແລະ ຈະບໍ່ສາມາດກູ້ຄືນໄດ້. ລະວັງຜົນກະທົບທີ່ສຳຄັນຕໍ່ຮູບລັກສະນະຂອງເວັບໄຊ.
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=ການລຶບມຸມມອງຜູ້ໃຊ້ແມ່ນການດຳເນີນການທີ່ບໍ່ສາມາດຍ້ອນກັບໄດ້.
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=ການລຶບ instance ແມ່ນການກະທຳທີ່ບໍ່ສາມາດຍົກເລີກໄດ້.
 deleting-an-object-definition-also-removes-its-data-records=ການລຶບ object definition ຍັງລຶບ object entries ຂອງມັນ. ການກະທຳນີ້ແມ່ນຖາວອນ ແລະ ບໍ່ສາມາດຍົກເລີກໄດ້.
 deleting-an-object-folder-will-move-its-object-definitions=ການລຶບ object folder ຈະຍ້າຍ object definitions ຂອງມັນໄປຍັງ object folder "ເລີ່ມຕົ້ນ". ການກະທຳນີ້ແມ່ນຖາວອນ ແລະ ບໍ່ສາມາດຍົກເລີກໄດ້.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_mk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_mk.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_my.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_my.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Het verwijderen van ee
 deleting-a-site-is-an-action-impossible-to-revert=Het verwijderen van een site kan niet worden teruggedraaid. Alle inhoud wordt verwijderd en het zal niet mogelijk zijn deze te herstellen.
 deleting-a-style-book-is-an-action-impossible-to-revert=Het verwijderen van een stijlboek kan niet worden teruggedraaid. Alle stijlboektokens en -waarden zullen worden verwijderd en het zal niet mogelijk zijn ze te herstellen. Pas op voor kritieke gevolgen voor het uiterlijk van de site.
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Het verwijderen van een gebruikersweergave is een actie die niet ongedaan gemaakt kan worden.
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Het verwijderen van een instantie kan niet worden teruggedraaid.
 deleting-an-object-definition-also-removes-its-data-records=Bij het verwijderen van een objectdefinitie worden ook de objectrecords verwijderd. Deze actie is permanent en onomkeerbaar.
 deleting-an-object-folder-will-move-its-object-definitions=Als u een objectmap verwijdert, worden de objectdefinities verplaatst naar de objectmap "Niet gecategoriseerd". Deze actie is definitief en kan niet ongedaan worden gemaakt.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Het verwijderen van ee
 deleting-a-site-is-an-action-impossible-to-revert=Het verwijderen van een site kan niet worden teruggedraaid. Alle inhoud wordt verwijderd en het zal niet mogelijk zijn deze te herstellen.
 deleting-a-style-book-is-an-action-impossible-to-revert=Het verwijderen van een stijlboek kan niet worden teruggedraaid. Alle stijlboektokens en -waarden zullen worden verwijderd en het zal niet mogelijk zijn ze te herstellen. Pas op voor kritieke gevolgen voor het uiterlijk van de site.
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Het verwijderen van een gebruikersweergave is een actie die niet ongedaan gemaakt kan worden.
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Het verwijderen van een instantie kan niet worden teruggedraaid.
 deleting-an-object-definition-also-removes-its-data-records=Bij het verwijderen van een objectdefinitie worden ook de objectrecords verwijderd. Deze actie is permanent en onomkeerbaar.
 deleting-an-object-folder-will-move-its-object-definitions=Als u een objectmap verwijdert, worden de objectdefinities verplaatst naar de objectmap "Niet gecategoriseerd". Deze actie is definitief en kan niet ongedaan worden gemaakt.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_no.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_no.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Excluir um conjunto de
 deleting-a-site-is-an-action-impossible-to-revert=Excluir um site é uma ação impossível de se reverter. Todo conteúdo será removido e não poderá ser recuperado.
 deleting-a-style-book-is-an-action-impossible-to-revert=A exclusão de um livro de estilos é uma ação que não pode ser revertida. Todos os tokens e valores do Livro de Estilos serão removidos e não será possível recuperá-los. Cuidado com o impacto crítico na aparência e percepção do site.
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=A ação de excluir uma visualização de usuário é irreversível.
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=A exclusão de uma instância é uma ação irreversível.
 deleting-an-object-definition-also-removes-its-data-records=A exclusão de uma definição de objeto também remove suas entradas de objeto. Esta ação é permanente e irreversível.
 deleting-an-object-folder-will-move-its-object-definitions=Excluir uma pasta de objeto moverá as definições do objeto à pasta de objeto "Não categorizado". Esta ação é permanente e irreversível.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Excluir um conjunto de
 deleting-a-site-is-an-action-impossible-to-revert=Excluir um site é uma ação impossível de se reverter. Todo conteúdo será removido e não poderá ser recuperado.
 deleting-a-style-book-is-an-action-impossible-to-revert=A exclusão de um livro de estilos é uma ação que não pode ser revertida. Todos os tokens e valores do Livro de Estilos serão removidos e não será possível recuperá-los. Cuidado com o impacto crítico na aparência e percepção do site.
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=A ação de excluir uma visualização de usuário é irreversível.
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=A exclusão de uma instância é uma ação irreversível.
 deleting-an-object-definition-also-removes-its-data-records=A exclusão de uma definição de objeto também remove suas entradas de objeto. Esta ação é permanente e irreversível.
 deleting-an-object-folder-will-move-its-object-definitions=Excluir uma pasta de objeto moverá as definições do objeto à pasta de objeto "Não categorizado". Esta ação é permanente e irreversível.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Borttagning av en frag
 deleting-a-site-is-an-action-impossible-to-revert=Borttagning av en webbplats är en åtgärd som inte kan återställas. Allt innehåll tas bort och det går inte att återställa det.
 deleting-a-style-book-is-an-action-impossible-to-revert=Borttagning av en stilbok är en åtgärd som inte kan återställas. Alla tokens och värden i stilboken tas bort och det går inte att återställa dem. Se upp för hur webbplatsens utseende och känsla kan påverkas.
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Borttagning av en användarvy är en åtgärd som inte kan återställas.
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Borttagning av en instans är en åtgärd som inte kan återställas.
 deleting-an-object-definition-also-removes-its-data-records=Om du tar bort en objektdefinition tas även objektposter bort. Den här åtgärden är permanent och kan inte ångras.
 deleting-an-object-folder-will-move-its-object-definitions=Om du tar bort en objektmapp flyttas dess objektdefinitioner till objektmappen "Okategoriserad". Den här åtgärden är permanent och kan inte ångras.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=การลบเซ�
 deleting-a-site-is-an-action-impossible-to-revert=การลบเซ็ตจะไม่สามารถย้อนกลับได้ เนื้อหาทั้งหมดจะถูกลบออกและจะไม่สามารถกู้คืนได้
 deleting-a-style-book-is-an-action-impossible-to-revert=การลบสไตล์บุคจะไม่สามารถย้อนกลับได้ โทเค็นและค่าของสไตล์บุคทั้งหมดจะถูกลบออกและไม่สามารถกู้คืนได้ ระวังผลกระทบที่จะเกิดต่อรูปลักษณ์และความรู้สึกของไซต์
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=การลบคำจำกัดความของออบเจ็กต์จะทำให้ออบเจ็กต์ถูกลบออกด้วย การดำเนินการนี้เป็นแบบถาวรและไม่สามารถยกเลิกได้
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=删除片段集是一�
 deleting-a-site-is-an-action-impossible-to-revert=删除站点是一项无法还原的操作。所有内容都将移除，无法恢复。
 deleting-a-style-book-is-an-action-impossible-to-revert=删除样式簿是一项无法还原的操作。所有样式簿标记和值都将移除，无法恢复。请注意这会对网站外观和感觉产生严重影响。
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=删除用户视图是无法撤消的操作。
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=删除实例是一项无法还原的操作。
 deleting-an-object-definition-also-removes-its-data-records=删除对象定义也会移除其对象条目。此操作是永久性的，无法撤消。
 deleting-an-object-folder-will-move-its-object-definitions=删除对象文件夹会将其对象定义移至"未分类"对象文件夹。此操作是永久性的，无法撤消。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
@@ -6492,6 +6492,7 @@ deleting-a-fragment-set-is-an-action-impossible-to-revert=Deleting a fragment se
 deleting-a-site-is-an-action-impossible-to-revert=Deleting a site is an action impossible to revert. All content will be removed and it will not be possible to recover it. (Automatic Copy)
 deleting-a-style-book-is-an-action-impossible-to-revert=Deleting a style book is an action impossible to revert. All style book tokens and values will be removed and it will not be possible to recover it. Watch out for a critical impact on the site's look and feel. (Automatic Copy)
 deleting-a-user-view-is-an-action-that-cannot-be-reversed=Deleting a user view is an action that cannot be reversed. (Automatic Copy)
+deleting-a-version-is-an-action-impossible-to-revert=Deleting a version is an action impossible to revert. Are you sure you want to continue deleting this page version? (Automatic Copy)
 deleting-an-instance-is-an-action-impossible-to-revert=Deleting an instance is an action impossible to revert. (Automatic Copy)
 deleting-an-object-definition-also-removes-its-data-records=Deleting an object definition also removes its object entries. This action is permanent and cannot be undone. (Automatic Copy)
 deleting-an-object-folder-will-move-its-object-definitions=Deleting an object folder will move its object definitions to the "Default" object folder. This action is permanent and cannot be undone. (Automatic Copy)

--- a/modules/test/playwright/tests/site-admin-web/main/fixtures/localizationPagesTest.ts
+++ b/modules/test/playwright/tests/site-admin-web/main/fixtures/localizationPagesTest.ts
@@ -5,6 +5,7 @@
 
 import {test} from '@playwright/test';
 
+import {getHeader} from '../../../../helpers/ApiHelpers';
 import {LocalizationInstanceSettingsPage} from '../pages/LocalizationInstanceSettingsPage';
 
 const localizationPagesTest = test.extend<{
@@ -22,28 +23,46 @@ const localizationPagesTest = test.extend<{
 			await use();
 		}
 		finally {
+			try {
 
-			// Render the admin UI in English regardless of the current
-			// instance default language, so the settings navigation and
-			// controls resolve when the test left the instance in another
-			// language.
+				// Render the admin UI in English regardless of the current
+				// instance default language, so the settings navigation and
+				// controls resolve when the test left the instance in another
+				// language. Both calls carry the authenticity token: without
+				// it the portal answers Forbidden, and the body it returns for
+				// that is not always JSON.
 
-			const response = await page.request.get(
-				'/o/headless-admin-user/v1.0/my-user-account'
-			);
+				const response = await page.request.get(
+					'/o/headless-admin-user/v1.0/my-user-account',
+					{headers: await getHeader(page)}
+				);
 
-			const myUserAccount = await response.json();
+				const myUserAccount = await response.json();
 
-			await page.request.patch(
-				`/o/headless-admin-user/v1.0/user-accounts/${myUserAccount.id}`,
-				{data: {languageId: 'en_US'}}
-			);
+				await page.request.patch(
+					`/o/headless-admin-user/v1.0/user-accounts/${myUserAccount.id}`,
+					{
+						data: {languageId: 'en_US'},
+						headers: await getHeader(page),
+					}
+				);
 
-			await page.reload();
+				await page.reload();
+			}
+			finally {
 
-			await localizationInstanceSettingsPage.goto('Language', false);
+				// The instance default language is instance wide state that
+				// every later test inherits, so restore it even when the steps
+				// above fail. Leaving it set fails sign-in verification,
+				// object definition labels, and site page creation across
+				// every file and worker that follows.
 
-			await localizationInstanceSettingsPage.setDefaultLanguage('en_US');
+				await localizationInstanceSettingsPage.goto('Language', false);
+
+				await localizationInstanceSettingsPage.setDefaultLanguage(
+					'en_US'
+				);
+			}
 		}
 	},
 });


### PR DESCRIPTION
Este es un front de pruebas que me ha servido a mí para probar la API introducida en https://github.com/liferay-page-management/liferay-portal/pull/18855, no una implementación pulida de LPD-101437. Es totalmente up-to-you usar algo, adaptarlo, o descartarlo por completo cuando implementes el ticket.

Solo lo paso por si sirve como base para probar la PR de arriba mientras trabajas en LPD-101437, sin ninguna expectativa de que se merge.

## Contenido

Los 4 commits de LPD-101437 encima de la rama de LPD-90029 (para que compile contra la nueva API):

- `LPD-101437 Add language key for the delete version modal`
- `LPD-101437 buildLang`
- `LPD-101437 Add deletePageVersion service`
- `LPD-101437 Wire the delete action into the version history UI`
